### PR TITLE
Enable maverick node for e2e test

### DIFF
--- a/test/e2e/app/config.go
+++ b/test/e2e/app/config.go
@@ -22,7 +22,6 @@ type Config struct {
 	PrivValKey       string                      `toml:"privval_key"`
 	PrivValState     string                      `toml:"privval_state"`
 	Misbehaviors     map[string]string           `toml:"misbehaviors"`
-	KeyType          string                      `toml:"key_type"`
 }
 
 // LoadConfig loads the configuration from disk.

--- a/test/e2e/app/main.go
+++ b/test/e2e/app/main.go
@@ -158,8 +158,9 @@ func startMaverick(cfg *Config) error {
 		misbehaviors[height] = mcs.MisbehaviorList[misbehaviorString]
 	}
 
+	privKey, _ := maverick.LoadOrGenFilePV(tmcfg.PrivValidatorKeyFile(), tmcfg.PrivValidatorStateFile(), tmcfg.PrivKeyType)
 	n, err := maverick.NewNode(tmcfg,
-		maverick.LoadOrGenFilePV(tmcfg.PrivValidatorKeyFile(), tmcfg.PrivValidatorStateFile()),
+		privKey,
 		nodeKey,
 		proxy.NewLocalClientCreator(app),
 		maverick.DefaultGenesisDocProviderFunc(tmcfg),

--- a/test/e2e/networks/ci.toml
+++ b/test/e2e/networks/ci.toml
@@ -36,7 +36,7 @@ seeds = ["seed01"]
 seeds = ["seed01"]
 snapshot_interval = 5
 perturb = ["disconnect"]
-#misbehaviors = { 1018 = "double-prevote" }
+misbehaviors = { 1018 = "double-prevote" }
 
 [node.validator02]
 seeds = ["seed02"]

--- a/test/maverick/consensus/misbehavior.go
+++ b/test/maverick/consensus/misbehavior.go
@@ -378,9 +378,11 @@ func defaultReceiveProposal(cs *State, proposal *types.Proposal) error {
 		return ErrInvalidProposalPOLRound
 	}
 
+	proposer := cs.Validators.SelectProposer(cs.state.LastProofHash, proposal.Height, proposal.Round)
+
 	p := proposal.ToProto()
 	// Verify signature
-	if !cs.Proposer.PubKey.VerifySignature(
+	if !proposer.PubKey.VerifySignature(
 		types.ProposalSignBytes(cs.state.ChainID, p), proposal.Signature) {
 		return ErrInvalidProposalSignature
 	}

--- a/test/maverick/consensus/replay.go
+++ b/test/maverick/consensus/replay.go
@@ -314,7 +314,7 @@ func (h *Handshaker) ReplayBlocks(
 			ChainId:         h.genDoc.ChainID,
 			InitialHeight:   h.genDoc.InitialHeight,
 			ConsensusParams: csParams,
-			Validators:      nextVals,
+			Validators:      nextVals, // ValidatorOrVoter: validator
 			AppStateBytes:   h.genDoc.AppState,
 		}
 		res, err := proxyApp.Consensus().InitChainSync(req)
@@ -338,7 +338,9 @@ func (h *Handshaker) ReplayBlocks(
 					return nil, err
 				}
 				state.Validators = types.NewValidatorSet(vals)
-				state.NextValidators = types.NewValidatorSet(vals).CopyIncrementProposerPriority(1)
+				state.Voters = types.SelectVoter(state.Validators, h.genDoc.Hash(), state.VoterParams)
+				// Should sync it with MakeGenesisState()
+				state.NextValidators = types.NewValidatorSet(vals)
 			} else if len(h.genDoc.Validators) == 0 {
 				// If validator set is not set in genesis and still empty after InitChain, exit.
 				return nil, fmt.Errorf("validator set is nil in genesis and still empty after InitChain")

--- a/test/maverick/consensus/replay_file.go
+++ b/test/maverick/consensus/replay_file.go
@@ -258,8 +258,8 @@ func (pb *playback) replayConsoleLoop() int {
 				switch tokens[1] {
 				case "short":
 					fmt.Printf("%v/%v/%v\n", rs.Height, rs.Round, rs.Step)
-				case "validators":
-					fmt.Println(rs.Validators)
+				case "voters":
+					fmt.Println(rs.Voters)
 				case "proposal":
 					fmt.Println(rs.Proposal)
 				case "proposal_block":

--- a/test/maverick/main.go
+++ b/test/maverick/main.go
@@ -181,7 +181,7 @@ func initFilesWithConfig(config *cfg.Config) error {
 		logger.Info("Found private validator", "keyFile", privValKeyFile,
 			"stateFile", privValStateFile)
 	} else {
-		pv = nd.GenFilePV(privValKeyFile, privValStateFile)
+		pv, _ = nd.GenFilePV(privValKeyFile, privValStateFile, config.PrivKeyType)
 		pv.Save()
 		logger.Info("Generated private validator", "keyFile", privValKeyFile,
 			"stateFile", privValStateFile)

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -121,11 +121,19 @@ type Provider func(*cfg.Config, log.Logger) (*Node, error)
 func DefaultNewNode(config *cfg.Config, logger log.Logger, misbehaviors map[int64]cs.Misbehavior) (*Node, error) {
 	nodeKey, err := p2p.LoadOrGenNodeKey(config.NodeKeyFile())
 	if err != nil {
-		return nil, fmt.Errorf("failed to load or gen node key %s, err: %w", config.NodeKeyFile(), err)
+		return nil, fmt.Errorf("failed to load or gen node key %s: %w", config.NodeKeyFile(), err)
+	}
+
+	privKey, err := LoadOrGenFilePV(
+		config.PrivValidatorKeyFile(),
+		config.PrivValidatorStateFile(),
+		config.PrivValidatorKeyType())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a private key: %s", err)
 	}
 
 	return NewNode(config,
-		LoadOrGenFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile()),
+		privKey,
 		nodeKey,
 		proxy.DefaultClientCreator(config.ProxyApp, config.ABCI, config.DBDir()),
 		DefaultGenesisDocProviderFunc(config),
@@ -466,7 +474,8 @@ func createConsensusReactor(config *cfg.Config,
 	if privValidator != nil {
 		consensusState.SetPrivValidator(privValidator)
 	}
-	consensusReactor := cs.NewReactor(consensusState, waitSync, cs.ReactorMetrics(csMetrics))
+	consensusReactor := cs.NewReactor(consensusState, waitSync, config.P2P.RecvAsync, config.P2P.ConsensusRecvBufSize,
+		cs.ReactorMetrics(csMetrics))
 	consensusReactor.SetLogger(consensusLogger)
 	// services which will be publishing and/or subscribing for messages (events)
 	// consensusReactor will set it on consensusState and blockExecutor
@@ -618,6 +627,7 @@ func createPEXReactorAndAddToSwitch(addrBook pex.AddrBook, config *cfg.Config,
 			// https://github.com/tendermint/tendermint/issues/3523
 			SeedDisconnectWaitPeriod:     28 * time.Hour,
 			PersistentPeersMaxDialPeriod: config.P2P.PersistentPeersMaxDialPeriod,
+			RecvBufSize:                  config.P2P.PexRecvBufSize,
 		})
 	pexReactor.SetLogger(logger.With("module", "pex"))
 	sw.AddReactor("PEX", pexReactor)
@@ -648,10 +658,17 @@ func startStateSync(ssR *statesync.Reactor, bcR fastSyncReactor, conR *cs.Reacto
 	}
 
 	go func() {
-		state, _, commit, err := ssR.Sync(stateProvider, config.DiscoveryTime)
+		state, previousState, commit, err := ssR.Sync(stateProvider, config.DiscoveryTime)
 		if err != nil {
 			ssR.Logger.Error("State sync failed", "err", err)
 			return
+		}
+		if previousState.LastBlockHeight > 0 {
+			err = stateStore.Bootstrap(previousState)
+			if err != nil {
+				ssR.Logger.Error("Failed to bootstrap node with previous state", "err", err)
+				return
+			}
 		}
 		err = stateStore.Bootstrap(state)
 		if err != nil {
@@ -813,7 +830,7 @@ func NewNode(config *cfg.Config,
 	// we should clean this whole thing up. See:
 	// https://github.com/tendermint/tendermint/issues/4644
 	stateSyncReactor := statesync.NewReactor(proxyApp.Snapshot(), proxyApp.Query(),
-		config.P2P.RecvAsync, config.P2P.BlockchainRecvBufSize)
+		config.P2P.RecvAsync, config.P2P.StatesyncRecvBufSize)
 	stateSyncReactor.SetLogger(logger.With("module", "statesync"))
 
 	nodeInfo, err := makeNodeInfo(config, nodeKey, txIndexer, genDoc, state)


### PR DESCRIPTION
Splited PR from https://github.com/line/ostracon/pull/290
## Description

Fix the maverick node implementation with Ostracon features. I implemented with comparing the below.

- Compare files:
<img width="511" alt="screenshot 2021-08-10 13 25 31" src="https://user-images.githubusercontent.com/1164270/128808115-cb8c0d30-212b-406b-b6c2-662fe37115d1.png">

- Compare functions on between `test/maverick/consensus/misbehavior.go` and `consensus/state.go`
<img width="941" alt="screenshot 2021-08-10 13 25 48" src="https://user-images.githubusercontent.com/1164270/128808123-9c3b0d5d-77b1-4fa7-af98-e54c560e31d7.png">

Closes: #289

