### PR TITLE
chore: added extra timing info regarding block generation

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -366,7 +366,6 @@ func execBlockOnProxyApp(
 	}
 	proxyAppConn.SetGlobalCallback(proxyCb)
 
-	startTime := time.Now()
 	commitInfo := getBeginBlockValidatorInfo(block, store, initialHeight, voterParams)
 
 	byzVals := make([]abci.Evidence, 0)
@@ -392,6 +391,7 @@ func execBlockOnProxyApp(
 		return nil, err
 	}
 
+	startTime := time.Now()
 	// run txs of block
 	for _, tx := range block.Txs {
 		proxyAppConn.DeliverTxAsync(abci.RequestDeliverTx{Tx: tx}, nil)


### PR DESCRIPTION
added extra timing info regarding block generation.

It's going to show up in the logs like the following.

021/09/29-00:08:58.591 INF executed block exec_time=3.926 height=86037 module=state num_invalid_txs=0 num_valid_txs=15118 tps=3850
2021/09/29-00:09:00.564 INF committed state commit_time=1.564 height=86037 num_txs=15118 update_mempool_time=0.311
2021/09/29-00:09:00.565 INF block generated generation_time=5.901 height=86037 module=state num_txs=15118 tps=2561
