### PR TITLE
Modify omission of change to change ValidatorSet to VoterSet

### DIFF
--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2280,7 +2280,7 @@ func (cs *State) signVote(
 	}
 
 	addr := cs.privValidatorPubKey.Address()
-	valIdx, _ := cs.Validators.GetByAddress(addr)
+	valIdx, _ := cs.Voters.GetByAddress(addr)
 
 	vote := &types.Vote{
 		ValidatorAddress: addr,


### PR DESCRIPTION
## Description
- Corresponding to the omission of change from the validator set to the voter set during version upgrade work.
This commit change was not reflected.
https://github.com/line/ostracon/commit/25fe25c5a5f92f734b8236007916b065c7bb8494


