### PR TITLE
fix: Modify omission of change to change ValidatorSet to VoterSet for `maverick`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v1.0.2
+
+*Nov 08, 2021*
+
+* Fix bugs
+* Improve crypto/composite key
+
+### BREAKING CHANGES
+- Nothing
+
+### FEATURES
+- Nothing
+
+### IMPROVEMENTS
+- [test] [\#327](https://github.com/line/ostracon/pull/327) Add libsodium test on Github Actions
+- [crypto/composite] [\#335](https://github.com/line/ostracon/pull/335) Improve composite key Bytes/FromBytes and make tools
+- [security] [\#336](https://github.com/line/ostracon/pull/336) Remove unused package-lock.json
+- [bot] [\#337](https://github.com/line/ostracon/pull/337) Improve dependabot
+
+### BUG FIXES
+- [test] [\#338](https://github.com/line/ostracon/pull/338) bugfix: wrong binary name
+- [consensus] [\#340](https://github.com/line/ostracon/pull/340) Modify omission of change to change ValidatorSet to VoterSet
+
 ## v1.0.1
 
 *Sep 30, 2021*

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -399,19 +399,8 @@ func createMConnection(
 			// because msgBytes is on socket receive buffer yet so reactor can read it concurrently
 			copied := make([]byte, len(msgBytes))
 			copy(copied, msgBytes)
-			select {
-			case ch <- &BufferedMsg{
-				ChID: chID,
-				Peer: p,
-				Msg:  copied}:
-			default:
-				// if the channel is full, we abandon this message
-				// Should check `config.Config.XxxBufSize`
-				p.Logger.Error("Lost the message since BaseReactor.recvMsgBuf is full",
-					"reactor", reactor,
-					"msgBytes.len", len(msgBytes), "msgBytes", fmt.Sprintf("%X", msgBytes))
-				p.metrics.NumAbandonedPeerMsgs.With(labels...).Add(1)
-			}
+			// if the channel is full, we are blocking a message until it can send into the channel
+			ch <- &BufferedMsg{ChID: chID, Peer: p, Msg: copied}
 		} else {
 			reactor.Receive(chID, p, msgBytes)
 		}

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -1807,7 +1807,7 @@ func (cs *State) signVote(
 		return nil, errPubKeyIsNotSet
 	}
 	addr := cs.privValidatorPubKey.Address()
-	valIdx, _ := cs.Validators.GetByAddress(addr)
+	valIdx, _ := cs.Voters.GetByAddress(addr)
 
 	vote := &types.Vote{
 		ValidatorAddress: addr,


### PR DESCRIPTION
## Description
Corresponding to the omission of change from the validator set to the voter set during version upgrade work.
This commit change was not reflected.[25fe25c](https://github.com/line/ostracon/commit/25fe25c5a5f92f734b8236007916b065c7bb8494)

This PR is an additional modification of this PR https://github.com/line/ostracon/pull/340


