### PR TITLE
fix: Modify omission of change to change ValidatorSet to VoterSet for marverick

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -338,8 +338,8 @@ cd test/e2e && \
 
 ### Maverick
 
-**If you're changing the code in `consensus` package, please make sure to
-replicate all the changes in `./test/maverick/consensus`**. Maverick is a
+**If you're changing the code in `consensus` package or `node` package, please make sure to
+replicate all the changes in `./test/maverick/consensus`** and `./test/maverick/node`**. Maverick is a
 byzantine node used to assert that the validator gets punished for malicious
 behavior.
 

--- a/test/maverick/consensus/state.go
+++ b/test/maverick/consensus/state.go
@@ -1807,7 +1807,7 @@ func (cs *State) signVote(
 		return nil, errPubKeyIsNotSet
 	}
 	addr := cs.privValidatorPubKey.Address()
-	valIdx, _ := cs.Validators.GetByAddress(addr)
+	valIdx, _ := cs.Voters.GetByAddress(addr)
 
 	vote := &types.Vote{
 		ValidatorAddress: addr,


### PR DESCRIPTION
## Description
Corresponding to the omission of change from the validator set to the voter set during version upgrade work.
This commit change was not reflected.[25fe25c](https://github.com/line/ostracon/commit/25fe25c5a5f92f734b8236007916b065c7bb8494)

This PR is an additional modification of this PR #340



