### PR TITLE
Fix version.go (Rollback to only use `OCCoreSemVer`)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 name: Build & Push
-#  Build & Push rebuilds the ostracon docker image on every push to master and creation of tags
+#  Build & Push rebuilds the ostracon docker image on every push to main and creation of tags
 # and pushes the image to https://hub.docker.com/r/interchainio/simapp/tags
 on:
   pull_request:
@@ -24,23 +24,27 @@ jobs:
             VERSION=${GITHUB_REF#refs/tags/}
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+            DEFAULT_BRANCH=$(curl -s -H "Accept: application/vnd.github.v3+json" \
+                             https://api.github.com/repos/line/ostracon | \
+                             grep default_branch | \
+                             cut -d"\"" -f4)
+            if [ "$DEFAULT_BRANCH" = "$VERSION" ]; then
               VERSION=latest
             fi
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
+            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION%.*}"
           fi
           echo ::set-output name=tags::${TAGS}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@master
+#        with:
+#          platforms: all
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v1
 
 #      - name: Login to DockerHub
 #        if: ${{ github.event_name != 'pull_request' }}
@@ -49,11 +53,11 @@ jobs:
 #          username: ${{ secrets.DOCKERHUB_USERNAME }}
 #          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish to Docker Hub
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./DOCKER/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          #push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs.tags }}
+#      - name: Publish to Docker Hub
+#        uses: docker/build-push-action@v2
+#        with:
+#          context: .
+#          file: ./DOCKER/Dockerfile
+#          platforms: linux/amd64,linux/arm64
+#          push: ${{ github.event_name != 'pull_request' }}
+#          tags: ${{ steps.prep.outputs.tags }}

--- a/.github/workflows/proto-docker.yml
+++ b/.github/workflows/proto-docker.yml
@@ -3,9 +3,11 @@ on:
   pull_request:
     paths:
       - "tools/proto/*"
-#  push:
-#    paths:
-#      - "tools/proto/*"
+  push:
+    branches:
+      - main
+    paths:
+      - "tools/proto/*"
   schedule:
     # run this job once a month to recieve any go or buf updates
     - cron: "* * 1 * *"
@@ -24,15 +26,22 @@ jobs:
             VERSION=${GITHUB_REF#refs/tags/}
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+            DEFAULT_BRANCH=$(curl -s -H "Accept: application/vnd.github.v3+json" \
+                             https://api.github.com/repos/line/ostracon | \
+                             grep default_branch | \
+                             cut -d"\"" -f4)
+            if [ "$DEFAULT_BRANCH" = "$VERSION" ]; then
               VERSION=latest
             fi
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION%.*}"
+          fi
           echo ::set-output name=tags::${TAGS}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v1
 
 #      - name: Login to DockerHub
 #        uses: docker/login-action@v1
@@ -40,10 +49,10 @@ jobs:
 #          username: ${{ secrets.DOCKERHUB_USERNAME }}
 #          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Publish to Docker Hub
-        uses: docker/build-push-action@v2
-        with:
-          context: ./tools/proto
-          file: ./tools/proto/Dockerfile
-          push: false #${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs.tags }}
+#      - name: Publish to Docker Hub
+#        uses: docker/build-push-action@v2
+#        with:
+#          context: ./tools/proto
+#          file: ./tools/proto/Dockerfile
+#          push: ${{ github.event_name != 'pull_request' }}
+#          tags: ${{ steps.prep.outputs.tags }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,7 @@ builds:
   - id: "Ostracon"
     main: ./cmd/ostracon/main.go
     ldflags:
-      - -s -w -X github.com/line/ostracon/version.Version={{ .Version }}
+      - -s -w -X github.com/line/ostracon/version.OCCoreSemVer={{ .Version }}
     env:
       - CGO_ENABLED=0
     goos:

--- a/DOCKER/build.sh
+++ b/DOCKER/build.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-# Get the tag from the version, or try to figure it out.
 if [ -z "$TAG" ]; then
-	TAG=$(awk -F\" '/Version =/ { print $2; exit }' < ../version/version.go)
-fi
-if [ -z "$TAG" ]; then
-		echo "Please specify a tag."
-		exit 1
+	echo "Please specify a tag."
+	exit 1
 fi
 
 TAG_NO_PATCH=${TAG%.*}
@@ -16,5 +12,5 @@ read -p "==> Build 3 docker images with the following tags (latest, $TAG, $TAG_N
 echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-		docker build -t "ostracon/ostracon" -t "ostracon/ostracon:$TAG" -t "ostracon/ostracon:$TAG_NO_PATCH" .
+	docker build -t "ostracon/ostracon" -t "ostracon/ostracon:$TAG" -t "ostracon/ostracon:$TAG_NO_PATCH" -f ./Dockerfile ../
 fi

--- a/DOCKER/push.sh
+++ b/DOCKER/push.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-# Get the tag from the version, or try to figure it out.
 if [ -z "$TAG" ]; then
-	TAG=$(awk -F\" '/Version =/ { print $2; exit }' < ../version/version.go)
-fi
-if [ -z "$TAG" ]; then
-		echo "Please specify a tag."
-		exit 1
+	echo "Please specify a tag."
+	exit 1
 fi
 
 TAG_NO_PATCH=${TAG%.*}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ else
   BUILD_TAGS += r2ishiguro
   LIBSODIUM_TARGET =
 endif
-LD_FLAGS = -X github.com/line/ostracon/version.Version=$(VERSION)
+LD_FLAGS = -X github.com/line/ostracon/version.OCCoreSemVer=$(VERSION)
 BUILD_FLAGS = -mod=readonly -ldflags "$(LD_FLAGS)"
 HTTPS_GIT := https://github.com/line/ostracon.git
 DOCKER_BUF := docker run -v $(shell pwd):/workspace --workdir /workspace bufbuild/buf

--- a/cmd/ostracon/commands/version.go
+++ b/cmd/ostracon/commands/version.go
@@ -13,6 +13,6 @@ var VersionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Show version info",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version.Version)
+		fmt.Println(version.OCCoreSemVer)
 	},
 }

--- a/cmd/ostracon/commands/version_test.go
+++ b/cmd/ostracon/commands/version_test.go
@@ -1,0 +1,11 @@
+package commands
+
+import (
+	"github.com/line/ostracon/version"
+	"testing"
+)
+
+func TestVersionCmd(t *testing.T) {
+	version.OCCoreSemVer = "test version"
+	VersionCmd.Run(VersionCmd, nil)
+}

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -4,13 +4,9 @@ set -e
 # WARN: non hermetic build (people must run this script inside docker to
 # produce deterministic binaries).
 
-# Get the version from the environment, or try to figure it out.
-if [ -z $VERSION ]; then
-	VERSION=$(awk -F\" '/Version =/ { print $2; exit }' < version/version.go)
-fi
 if [ -z "$VERSION" ]; then
-    echo "Please specify a version."
-    exit 1
+	echo "Please specify a version."
+	exit 1
 fi
 echo "==> Building version $VERSION..."
 
@@ -19,8 +15,6 @@ echo "==> Removing old directory..."
 rm -rf build/pkg
 mkdir -p build/pkg
 
-# Get the git commit
-VERSION := "$(git describe --always)"
 GIT_IMPORT="github.com/line/ostracon/version"
 
 # Determine the arch/os combos we're building for
@@ -61,7 +55,7 @@ done
 rm -rf ./build/dist
 mkdir -p ./build/dist
 for FILENAME in $(find ./build/pkg -mindepth 1 -maxdepth 1 -type f); do
-  FILENAME=$(basename "$FILENAME")
+	FILENAME=$(basename "$FILENAME")
 	cp "./build/pkg/${FILENAME}" "./build/dist/ostracon_${VERSION}_${FILENAME}"
 done
 

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -41,7 +41,7 @@ for arch in "${arch_list[@]}"; do
 	for os in "${os_list[@]}"; do
 		if [[ "$XC_EXCLUDE" !=  *" $os/$arch "* ]]; then
 			echo "--> $os/$arch"
-			GOOS=${os} GOARCH=${arch} go build -ldflags "-s -w -X ${GIT_IMPORT}.Version=${VERSION}" -tags="${BUILD_TAGS}" -o "build/pkg/${os}_${arch}/ostracon" ./cmd/ostracon
+			GOOS=${os} GOARCH=${arch} go build -ldflags "-s -w -X ${GIT_IMPORT}.OCCoreSemVer=${VERSION}" -tags="${BUILD_TAGS}" -o "build/pkg/${os}_${arch}/ostracon" ./cmd/ostracon
 		fi
 	done
 done

--- a/tools/tm-signer-harness/Dockerfile
+++ b/tools/tm-signer-harness/Dockerfile
@@ -1,4 +1,4 @@
-ARG TENDERMINT_VERSION=latest
-FROM ostracon/ostracon:${TENDERMINT_VERSION}
+ARG OSTRACON_VERSION=latest
+FROM ostracon/ostracon:${OSTRACON_VERSION}
 
 COPY tm-signer-harness /usr/bin/tm-signer-harness

--- a/tools/tm-signer-harness/Makefile
+++ b/tools/tm-signer-harness/Makefile
@@ -3,7 +3,7 @@
 OSTRACON_VERSION?=latest
 BUILD_TAGS?='ostracon'
 VERSION := $(shell git describe --always)
-BUILD_FLAGS = -ldflags "-X github.com/line/ostracon/version.Version=$(VERSION)
+BUILD_FLAGS = -ldflags "-X github.com/line/ostracon/version.OCCoreSemVer=$(VERSION)"
 
 .DEFAULT_GOAL := build
 

--- a/version/version.go
+++ b/version/version.go
@@ -4,24 +4,9 @@ var (
 	// OCCoreSemVer is the current version of Ostracon Core.
 	// It's the Semantic Version of the software.
 	OCCoreSemVer string
-
-	// GitCommit is the current HEAD set using ldflags.
-	GitCommit string
-
-	// Version is the built softwares version.
-	Version = OCCoreSemVer + "-" + LINECoreSemVer
 )
 
-func init() {
-	if GitCommit != "" {
-		Version += "-" + GitCommit
-	}
-}
-
 const (
-	// LINECoreSemVer is the current version of LINE Ostracon Core.
-	LINECoreSemVer = "0.3"
-
 	// ABCISemVer is the semantic version of the ABCI library
 	ABCISemVer = "0.17.0"
 


### PR DESCRIPTION
## Description

`version.go` does not work correctry. I fix to only use `OCCoreSemVer`.

* Remove Version/GitCommit/LINECoreSemVer: https://github.com/line/ostracon/commit/21c65f1d9c2c2e51e35e64ddb66826486ced4aa0
* Fix to support default_branch (Doesn't work `github.event.repository.default_branch`): https://github.com/line/ostracon/commit/375b1ae278b9f047dcf6284bddef5f59ac13cb88
  * See: https://docs.github.com/ja/actions/learn-github-actions/contexts
  * See: https://docs.github.com/en/rest/reference/repos#get-a-repository 
* Fix to get the version from git version (Doesn't work to get the version from `version.go`): https://github.com/line/ostracon/commit/26c9b0c7e827ecb435cb817c08c198cab858e87f
* nit: Fix to OSTRACON_VERSION: https://github.com/line/ostracon/commit/9205eeca81e5855e0b542bde03a3fe1960bc3ca1

## Appendix

### How to set `version.go:OCCoreSemVer`

> BUILD_FLAGS = -ldflags "-X github.com/line/ostracon/version.OCCoreSemVer=$(VERSION)"

### How to get `VERSION` from git the version

> VERSION := $(shell git describe --always)