### PR TITLE
Upgrade to super-linter-v4 for avoiding broken version

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Lint Code Base
-        uses: docker://github/super-linter:v3
+        uses: docker://github/super-linter:v4
         env:
           LINTER_RULES_PATH: .
           VALIDATE_ALL_CODEBASE: true


### PR DESCRIPTION
## Description

Should upgrade to super-linter-v4

See: https://github.com/github/super-linter/issues/2253
