### PR TITLE
Exclude auto-closing of issues in github actions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,4 +15,4 @@ jobs:
     for your contributions."
           days-before-stale: 10
           days-before-close: 4
-          exempt-pr-labels: "S:wip"
+          days-before-issue-close: -1


### PR DESCRIPTION
## Description

This PR changes the behavior of github actions where Issues with the `Stale` label are closed after 4 days.

- The *stale bot* will no longer close Issues with a `stale` label (PRs will still be closed in 4 days).
- An exception for `S:wip` label we don't use is removed.

There are a lot of options in `actions/stale`, but I didn't find any other ones that looked useful.

https://github.com/actions/stale

Closes: #XXX

