### PR TITLE
Upgrade to `line/tm-db-v2.0.0-init.1.0.20220121012851-61d2bc1d9486`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/herumi/bls-eth-go-binary v0.0.0-20200923072303-32b29e5d8cbf
 	github.com/lib/pq v1.10.5
 	github.com/libp2p/go-buffer-pool v0.0.2
-	github.com/line/tm-db/v2 v2.0.0-init.1.0.20210824011847-fcfa67dd3c70
+	github.com/line/tm-db/v2 v2.0.0-init.1.0.20220121012851-61d2bc1d9486
 	github.com/minio/highwayhash v1.0.2
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,8 @@ github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOS
 github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
 github.com/line/gorocksdb v0.0.0-20210406043732-d4bea34b6d55 h1:cXVtMiJkvQ4kn0pxM2svH1ncJbFgQsLHtnFC9qJj2VM=
 github.com/line/gorocksdb v0.0.0-20210406043732-d4bea34b6d55/go.mod h1:DHRJroSL7NaRkpvocRx3OtRsleXVsYSxBI9SfHFlTQ0=
-github.com/line/tm-db/v2 v2.0.0-init.1.0.20210824011847-fcfa67dd3c70 h1:Izv/u19P8salnSZGAgNHFugNlzWLgREiL+AmWK8C/lE=
-github.com/line/tm-db/v2 v2.0.0-init.1.0.20210824011847-fcfa67dd3c70/go.mod h1:wmkyPabXjtVZ1dvRofmurjaceghywtCSYGqFuFS+TbI=
+github.com/line/tm-db/v2 v2.0.0-init.1.0.20220121012851-61d2bc1d9486 h1:uvXQdcWaUyNsgkXBz375FpQ285WEJaLXhQ5HtoNK/GU=
+github.com/line/tm-db/v2 v2.0.0-init.1.0.20220121012851-61d2bc1d9486/go.mod h1:wmkyPabXjtVZ1dvRofmurjaceghywtCSYGqFuFS+TbI=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -1,13 +1,16 @@
 # We need to build in a Linux environment to support C libraries, e.g. RocksDB.
 # We use Debian instead of Alpine, so that we can use binary database packages
-# instead of spending time compiling them. 
-# -> There is currently no librocksdb-dev v6.17.x that is necessary by line/gorocksdb.
-# So we download rocksdb and build it.
-
+# instead of spending time compiling them.
 FROM golang:1.15
 
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y libleveldb-dev make libc-dev libtool >/dev/null
+
+# There is currently no librocksdb-dev v6.17.3 or higher that is necessary by line/gorocksdb.
+# So we download rocksdb and build it.
+# See:
+#    - line/gorocksdb: https://github.com/line/gorocksdb/pull/3
+#    - line/tm-db: https://github.com/line/tm-db/blob/main/tools/Dockerfile
 WORKDIR /
 RUN wget -O rocksdb-v6.20.3.tar.gz https://github.com/facebook/rocksdb/archive/v6.20.3.tar.gz
 RUN tar -zxvf rocksdb-v6.20.3.tar.gz
@@ -16,6 +19,7 @@ RUN cp /usr/local/lib/librocksdb.so* /usr/lib
 
 # Set up build directory /src/ostracon
 ENV OSTRACON_BUILD_OPTIONS badgerdb,boltdb,cleveldb,rocksdb
+ENV CGO_LDFLAGS -lrocksdb
 ENV LIBSODIUM 1
 WORKDIR /src/ostracon
 


### PR DESCRIPTION
## Description

Ostracon uses the same version of `line/tm-db` on lbm-sdk
- line/tm-db-v2.0.0-init.1.0.20220121012851-61d2bc1d9486:
  - https://github.com/line/tm-db/tree/61d2bc1d94864affed783739c160b95ed7f05996
- lbm-sdk:
  - https://github.com/line/lbm-sdk/blob/e2acac9105ef61402a75ca7e376e6a906aa2e6b2/go.mod#L35

NOTE:
`tm-db-v2.0.0-init.1.0.20220121012851-61d2bc1d9486` depends on `rocksdb/c.h` in `rdb/db.go`. So must set `CGO_FLAGS`
- https://github.com/line/tm-db/blob/61d2bc1d94864affed783739c160b95ed7f05996/rdb/db.go#L7
