### PR TITLE
Revert not to use `grpc/credentials/insecure` for compatibility

### DIFF
--- a/abci/client/grpc_client.go
+++ b/abci/client/grpc_client.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc/credentials/insecure"
-
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -56,9 +54,8 @@ func (cli *grpcClient) OnStart() error {
 
 RETRY_LOOP:
 	for {
-		conn, err := grpc.Dial(cli.addr,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-			grpc.WithContextDialer(dialerFunc))
+		//nolint:staticcheck // SA1019 Existing use of deprecated but supported dial option.
+		conn, err := grpc.Dial(cli.addr, grpc.WithInsecure(), grpc.WithContextDialer(dialerFunc))
 		if err != nil {
 			if cli.mustConnect {
 				return err

--- a/abci/example/example_test.go
+++ b/abci/example/example_test.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"google.golang.org/grpc/credentials/insecure"
-
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc"
@@ -150,9 +148,8 @@ func testGRPCSync(t *testing.T, app types.ABCIApplicationServer) {
 	})
 
 	// Connect to the socket
-	conn, err := grpc.Dial(socket,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(dialerFunc))
+	//nolint:staticcheck // SA1019 Existing use of deprecated but supported dial option.
+	conn, err := grpc.Dial(socket, grpc.WithInsecure(), grpc.WithContextDialer(dialerFunc))
 	if err != nil {
 		t.Fatalf("Error dialing GRPC server: %v", err.Error())
 	}

--- a/rpc/grpc/client_server.go
+++ b/rpc/grpc/client_server.go
@@ -3,8 +3,6 @@ package coregrpc
 import (
 	"net"
 
-	"google.golang.org/grpc/credentials/insecure"
-
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
@@ -28,9 +26,8 @@ func StartGRPCServer(ln net.Listener) error {
 // StartGRPCClient dials the gRPC server using protoAddr and returns a new
 // BroadcastAPIClient.
 func StartGRPCClient(protoAddr string) BroadcastAPIClient {
-	conn, err := grpc.Dial(protoAddr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithContextDialer(dialerFunc))
+	//nolint:staticcheck // SA1019 Existing use of deprecated but supported dial option.
+	conn, err := grpc.Dial(protoAddr, grpc.WithInsecure(), grpc.WithContextDialer(dialerFunc))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Description

We must have compatibility of `grpc-v1.33.2`. I revert not to use `grpc/credentials/insecure`.
- https://github.com/line/lbm-sdk/blob/e722aaf14af52b250a5f70858c3e0bde835722fd/go.mod#L67
- https://github.com/cosmos/cosmos-sdk/blob/v0.45.4/go.mod#L130-L132

See:
- We use `grpc/credentials/insecure`: https://github.com/line/ostracon/pull/368/commits/2ee2c37a7ab61b25a6e0a2327ca3141b2546df52
- They don't use: https://github.com/tendermint/tendermint/commit/c9c570e151d1082c8c5122368bbec0ffb4988fa8