### PR TITLE
Use Docker Buildx and Cache in e2e.yml

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,8 +15,12 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '^1.15.4'
+          go-version: '1.15.4'
+
       - uses: actions/checkout@v3
+        with:
+          submodules: true
+
       - uses: technote-space/get-diff-action@v6.0.1
         with:
           PATTERNS: |
@@ -24,10 +28,42 @@ jobs:
             go.mod
             go.sum
 
-      - name: Build
+      - name: Create cache directory
+        run: mkdir -p /tmp/.buildx-cache
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        if: "env.GIT_DIFF != ''"
+
+      - name: Load cached Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+        if: "env.GIT_DIFF != ''"
+
+      - name: Build e2e Docker
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./test/e2e/docker/Dockerfile
+          tags: ostracon/e2e-node
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          load: true
+        if: "env.GIT_DIFF != ''"
+
+      - name: Move cached Docker layers
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+        if: "env.GIT_DIFF != ''"
+
+      - name: Build e2e runner
         working-directory: test/e2e
-        # Run two make jobs in parallel, since we can't run steps in parallel.
-        run: make -j2 docker runner
+        run: make runner
         if: "env.GIT_DIFF != ''"
 
       - name: Run CI testnet

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,10 +8,16 @@ on:
       - main
       - release/**
 
+env:
+  TAG: ostracon/e2e-node
+  CACHE_DIR: /tmp/ostracon/e2etest
+
 jobs:
-  e2e-test:
+  e2e-build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    outputs:
+      CACHE_FILE: ${{ steps.prep.outputs.CACHE_FILE }}
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -29,36 +35,91 @@ jobs:
             go.sum
 
       - name: Create cache directory
-        run: mkdir -p /tmp/.buildx-cache
+        run: |
+          mkdir -p /tmp/.buildx-cache
+          mkdir -p ${{ env.CACHE_DIR }}
+
+      - name: Prepare
+        id: prep
+        run: |
+          HASH_GHE=${{ github.sha }}
+          VARIANT=$(TZ=UTC-9 date '+%Y%m')${HASH_GHE:0:7}
+          NAME_TAR="${VARIANT}.tar"
+          CACHE_FILE=${{ env.CACHE_DIR }}"/${NAME_TAR}"
+          echo "::set-output name=CACHE_FILE::${CACHE_FILE}"
+        if: "env.GIT_DIFF != ''"
+
+      - name: Get Docker Image File from cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHE_DIR }}
+          key: ${{ steps.prep.outputs.CACHE_FILE }}
+        if: "env.GIT_DIFF != ''"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-        if: "env.GIT_DIFF != ''"
+        if: "env.GIT_DIFF != '' && steps.cache.outputs.cache-hit != 'true'"
 
-      - name: Load cached Docker layers
+      - name: Get cached Docker layers
         uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-        if: "env.GIT_DIFF != ''"
+        if: "env.GIT_DIFF != '' && steps.cache.outputs.cache-hit != 'true'"
 
       - name: Build e2e Docker
         uses: docker/build-push-action@v2
         with:
           context: .
           file: ./test/e2e/docker/Dockerfile
-          tags: ostracon/e2e-node
+          tags: ${{ env.TAG }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           load: true
-        if: "env.GIT_DIFF != ''"
+        if: "env.GIT_DIFF != '' && steps.cache.outputs.cache-hit != 'true'"
 
       - name: Move cached Docker layers
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+        if: "env.GIT_DIFF != '' && steps.cache.outputs.cache-hit != 'true'"
+
+      - name: Save Docker Image
+        run: |
+          docker save -o ${{ steps.prep.outputs.CACHE_FILE }} ${{ env.TAG }}
+        if: "env.GIT_DIFF != '' && steps.cache.outputs.cache-hit != 'true'"
+
+  e2e-test:
+    needs: e2e-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.15.4'
+
+      - uses: actions/checkout@v3
+
+      - uses: technote-space/get-diff-action@v6.0.1
+        with:
+          PATTERNS: |
+            **/**.go
+            go.mod
+            go.sum
+
+      - name: Get Docker Image File from cache
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.CACHE_DIR }}
+          key: ${{ needs.e2e-build.outputs.CACHE_FILE }}
+        if: "env.GIT_DIFF != ''"
+
+      - name: Load Docker Image on Docker
+        run: |
+          docker load -i ${{ needs.e2e-build.outputs.CACHE_FILE }}
         if: "env.GIT_DIFF != ''"
 
       - name: Build e2e runner

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ libsodium:
 		git submodule update --init --recursive && \
 		cd $(LIBSODIUM_ROOT) && \
 		./autogen.sh && \
-		./configure --disable-shared --prefix="$(LIBSODIUM_OS)" $(LIBSODIUM_HOST) &&	\
+		./configure --disable-shared --prefix="$(LIBSODIUM_OS)" $(LIBSODIUM_HOST) && \
 		$(MAKE) && \
 		$(MAKE) install; \
 	fi

--- a/hello.go
+++ b/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}

--- a/hello.go
+++ b/hello.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("hello")
-}

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,7 +1,7 @@
 all: docker generator runner
 
 docker:
-	docker build --tag ostracon/e2e-node -f docker/Dockerfile ../..
+	docker build --progress=plain --tag ostracon/e2e-node -f docker/Dockerfile ../..
 
 # We need to build support for database backends into the app in
 # order to build a binary with an Ostracon node in it (for built-in

--- a/test/e2e/docker/Dockerfile
+++ b/test/e2e/docker/Dockerfile
@@ -6,33 +6,48 @@ FROM golang:1.15
 RUN apt-get -qq update -y && apt-get -qq upgrade -y >/dev/null
 RUN apt-get -qq install -y libleveldb-dev make libc-dev libtool >/dev/null
 
+ARG SRCDIR=/src/ostracon
+
 # There is currently no librocksdb-dev v6.17.3 or higher that is necessary by line/gorocksdb.
 # So we download rocksdb and build it.
 # See:
 #    - line/gorocksdb: https://github.com/line/gorocksdb/pull/3
 #    - line/tm-db: https://github.com/line/tm-db/blob/main/tools/Dockerfile
-WORKDIR /
-RUN wget -O rocksdb-v6.20.3.tar.gz https://github.com/facebook/rocksdb/archive/v6.20.3.tar.gz
-RUN tar -zxvf rocksdb-v6.20.3.tar.gz
-RUN cd rocksdb-6.20.3 && make -j2 shared_lib && make install-shared
+ARG ROCKSDB_VERSION=6.20.3
+ARG ROCKSDB_FILE=rocksdb-v${ROCKSDB_VERSION}.tar.gz
+ARG ROCKSDB_DIR=rocksdb-${ROCKSDB_VERSION}
+RUN wget -O ${ROCKSDB_FILE} https://github.com/facebook/rocksdb/archive/v${ROCKSDB_VERSION}.tar.gz
+RUN tar -zxvf ${ROCKSDB_FILE}
+RUN cd ${ROCKSDB_DIR} && make -j2 shared_lib && make install-shared
 RUN cp /usr/local/lib/librocksdb.so* /usr/lib
+RUN rm -rf ${ROCKSDB_FILE} ${ROCKSDB_DIR}
 
-# Set up build directory /src/ostracon
+# Build/Install libsodium separately (for layer caching)
+ARG VRF_ROOT=crypto/vrf/internal/vrf
+ARG LIBSODIUM_ROOT=${VRF_ROOT}/libsodium
+ARG LIBSODIUM_OS=${SRCDIR}/${VRF_ROOT}/sodium/linux_amd64
+COPY ${LIBSODIUM_ROOT} ${LIBSODIUM_ROOT}
+RUN cd ${LIBSODIUM_ROOT} && \
+    ./autogen.sh && \
+    ./configure --disable-shared --prefix="${LIBSODIUM_OS}" && \
+    make && \
+    make install
+RUN rm -rf ${LIBSODIUM_ROOT}
+
 ENV OSTRACON_BUILD_OPTIONS badgerdb,boltdb,cleveldb,rocksdb
 ENV CGO_LDFLAGS -lrocksdb
 ENV LIBSODIUM 1
-WORKDIR /src/ostracon
 
 # Fetch dependencies separately (for layer caching)
-COPY go.mod go.sum ./
-RUN go mod download
+COPY go.mod go.sum ${SRCDIR}
+RUN cd ${SRCDIR} && go mod download
 
 # Build Ostracon and install into /usr/bin/ostracon
-COPY . .
-RUN make build && cp build/ostracon /usr/bin/ostracon
+COPY . ${SRCDIR}
 COPY test/e2e/docker/entrypoint* /usr/bin/
-RUN cd test/e2e && make maverick && cp build/maverick /usr/bin/maverick
-RUN cd test/e2e && make node && cp build/node /usr/bin/app
+RUN cd ${SRCDIR} && make build && cp build/ostracon /usr/bin/ostracon
+RUN cd ${SRCDIR}/test/e2e && make maverick && cp build/maverick /usr/bin/maverick
+RUN cd ${SRCDIR}/test/e2e && make node && cp build/node /usr/bin/app
 
 # Set up runtime directory. We don't use a separate runtime image since we need
 # e.g. leveldb and rocksdb which are already installed in the build image.


### PR DESCRIPTION
## Description

### Current
18m 8s

|  Build  |  CI Test |
|  ----  | ----  |
|  13m 55s  |  3m 46s  |

* Summary: https://github.com/line/ostracon/actions/runs/2337125338
* Detail: https://github.com/line/ostracon/runs/6466489758?check_suite_focus=true

### Use cache on Docker Image Layer
Reduce the build time: 
11m 40s
|  Build  |  CI Test  |  Get Docker Image Layer Cache  |
|  ----  | ----  |  ----  |
|  5m 53s  |  4m 4s  |  26s  |

* Summary: https://github.com/line/ostracon/actions/runs/2349172352
* Detail: https://github.com/line/ostracon/runs/6500100614?check_suite_focus=true

### Use cache on Docker Image File
Cut the build time, but increase the saving time of Docker Image:
7m 9s
|  Build  |  Save  |  Store  |
|  ----  | ----  |  ----  |
|  5m 58s  |  2m 1s  |  51s  |

|  CI Test  |  Get Docker Image Cache File  |  Load Docker Image File  |
|  ----  | ----  |  ----  |
|  3m 18s  |  48s  |  1m 56s  |

* Summary: https://github.com/line/ostracon/actions/runs/2357337282
* Detail: https://github.com/line/ostracon/runs/6523197271?check_suite_focus=true

