### PR TITLE
Add KMS functionality

### DIFF
--- a/cmd/ostracon/commands/init.go
+++ b/cmd/ostracon/commands/init.go
@@ -8,7 +8,6 @@ import (
 	cfg "github.com/line/ostracon/config"
 	"github.com/line/ostracon/crypto"
 	tmos "github.com/line/ostracon/libs/os"
-	tmrand "github.com/line/ostracon/libs/rand"
 	"github.com/line/ostracon/node"
 	"github.com/line/ostracon/p2p"
 	"github.com/line/ostracon/privval"
@@ -43,7 +42,7 @@ func initFiles(cmd *cobra.Command, args []string) error {
 }
 
 func initFilesWithConfig(config *cfg.Config) (err error) {
-	chainID := fmt.Sprintf("test-chain-%v", tmrand.Str(6))
+	chainID := config.ChainID()
 
 	// private validator
 	var pubKey crypto.PubKey
@@ -114,11 +113,14 @@ func initFilesWithConfig(config *cfg.Config) (err error) {
 
 	// Save default settings with additional command-line specified options (default settings implicitly saved by
 	// root.go will be overwritten) when all operations succeed.
+	// If no configuration file exists when the `init` subcommand is executed and a new file is implicitly
+	// created with default settings, overwrite with specified ones by the command line options.
 	configFile = config.Path()
-	if tmos.FileExists(configFile) {
-		logger.Info("Found config.toml", "path", configFile)
+	if !configFileGenerated && tmos.FileExists(configFile) {
+		logger.Info("Found existing configuration", "path", configFile)
 	} else {
 		config.Save()
+		logger.Info("Generated configuration file", "path", configFile)
 	}
 
 	return nil

--- a/cmd/ostracon/commands/init.go
+++ b/cmd/ostracon/commands/init.go
@@ -84,6 +84,10 @@ func initFilesWithConfig(config *cfg.Config) error {
 		}
 	}()
 
+	// Save default settings with additional command-line specified options (default settings implicitly saved by
+	// root.go will be overwritten).
+	config.Save()
+
 	nodeKeyFile := config.NodeKeyFile()
 	if tmos.FileExists(nodeKeyFile) {
 		logger.Info("Found node key", "path", nodeKeyFile)

--- a/cmd/ostracon/commands/init_test.go
+++ b/cmd/ostracon/commands/init_test.go
@@ -1,0 +1,148 @@
+package commands
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/BurntSushi/toml"
+	cfg "github.com/line/ostracon/config"
+	"github.com/line/ostracon/crypto/ed25519"
+	"github.com/line/ostracon/privval"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitCmd(t *testing.T) {
+	setupEnv(t)
+	err := RootCmd.PersistentPreRunE(RootCmd, nil)
+	require.NoError(t, err)
+	cmd := NewInitCmd()
+	err = cmd.RunE(cmd, nil)
+	require.NoError(t, err)
+}
+
+func TestInitCmdWithKMSOptions(t *testing.T) {
+	dir := setupEnv(t)
+	config := cfg.TestConfig()
+	config.SetRoot(dir)
+	cfg.EnsureRoot(dir)
+	_ = os.Remove(config.Path()) // config.toml must be generated newly
+
+	WithMockKMS(t, dir, config.ChainID(), func(expected string) {
+		config.PrivValidatorListenAddr = expected
+		err := RootCmd.PersistentPreRunE(RootCmd, nil)
+		require.NoError(t, err)
+		require.NoError(t, initFilesWithConfig(config))
+		require.NoError(t, err)
+		require.NoFileExists(t, config.PrivValidatorKeyFile())
+		settingsMustBeContained(t, config.Path(), "priv_validator_laddr", expected)
+	})
+}
+
+func WithMockKMS(t *testing.T, dir, chainID string, f func(string)) {
+	// refer to the source cmd/priv_validator_server/main.go
+
+	// obtain an address using a vacancy port number
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	addr := listener.Addr().String()
+	if err = listener.Close(); err != nil {
+		t.Fatal(err)
+		return
+	}
+
+	// start mock kms server
+	shutdown := make(chan string)
+	go func() {
+		logger.Info(fmt.Sprintf("MockKMS starting: [%s] %s", chainID, addr))
+		privKey := ed25519.GenPrivKeyFromSecret([]byte("🏺"))
+		pv := privval.NewFilePV(privKey, path.Join(dir, "keyfile"), path.Join(dir, "statefile"))
+		connTimeout := 5 * time.Second
+		dialer := privval.DialTCPFn(addr, connTimeout, ed25519.GenPrivKeyFromSecret([]byte("🔌")))
+		sd := privval.NewSignerDialerEndpoint(logger, dialer)
+		ss := privval.NewSignerServer(sd, chainID, pv)
+		err := ss.Start()
+		if err != nil {
+			panic(err)
+		}
+		logger.Info("MockKMS started")
+		<-shutdown
+		logger.Info("MockKMS stopping")
+		if err = ss.Stop(); err != nil {
+			panic(err)
+		}
+		logger.Info("MockKMS stopped")
+	}()
+	defer func() {
+		shutdown <- "SHUTDOWN"
+	}()
+
+	f(addr)
+}
+
+func settingsMustBeContained(t *testing.T, file string, key, value string) {
+	var config map[string]interface{}
+	_, err := toml.DecodeFile(file, &config)
+	require.NoError(t, err)
+	require.Equal(t, value, config[key])
+}
+
+//func TestResetStateCmd(t *testing.T) {
+//	setupEnv(t)
+//	err := ResetStateCmd.RunE(ResetStateCmd, nil)
+//	require.NoError(t, err)
+//}
+//
+//func TestResetPrivValidatorCmd(t *testing.T) {
+//	setupEnv(t)
+//	err := ResetPrivValidatorCmd.RunE(ResetPrivValidatorCmd, nil)
+//	require.NoError(t, err)
+//}
+//func Test_ResetAll(t *testing.T) {
+//	config := cfg.TestConfig()
+//	dir := t.TempDir()
+//	config.SetRoot(dir)
+//	cfg.EnsureRoot(dir)
+//	require.NoError(t, initFilesWithConfig(config))
+//	pv := privval.LoadFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile())
+//	pv.LastSignState.Height = 10
+//	pv.Save()
+//	require.NoError(t, resetAll(config.DBDir(), config.P2P.AddrBookFile(), config.PrivValidatorKeyFile(),
+//		config.PrivValidatorStateFile(), config.PrivKeyType, logger))
+//	require.DirExists(t, config.DBDir())
+//	require.NoFileExists(t, filepath.Join(config.DBDir(), "block.db"))
+//	require.NoFileExists(t, filepath.Join(config.DBDir(), "state.db"))
+//	require.NoFileExists(t, filepath.Join(config.DBDir(), "evidence.db"))
+//	require.NoFileExists(t, filepath.Join(config.DBDir(), "tx_index.db"))
+//	require.FileExists(t, config.PrivValidatorStateFile())
+//	pv = privval.LoadFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile())
+//	require.Equal(t, int64(0), pv.LastSignState.Height)
+//}
+//
+//func Test_ResetState(t *testing.T) {
+//	config := cfg.TestConfig()
+//	dir := t.TempDir()
+//	config.SetRoot(dir)
+//	cfg.EnsureRoot(dir)
+//	require.NoError(t, initFilesWithConfig(config))
+//	pv := privval.LoadFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile())
+//	pv.LastSignState.Height = 10
+//	pv.Save()
+//	require.NoError(t, resetState(config.DBDir(), logger))
+//	require.DirExists(t, config.DBDir())
+//	require.NoFileExists(t, filepath.Join(config.DBDir(), "block.db"))
+//	require.NoFileExists(t, filepath.Join(config.DBDir(), "state.db"))
+//	require.NoFileExists(t, filepath.Join(config.DBDir(), "evidence.db"))
+//	require.NoFileExists(t, filepath.Join(config.DBDir(), "tx_index.db"))
+//	require.FileExists(t, config.PrivValidatorStateFile())
+//	pv = privval.LoadFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile())
+//	// private validator state should still be in tact.
+//	require.Equal(t, int64(10), pv.LastSignState.Height)
+//}

--- a/cmd/ostracon/commands/reset.go
+++ b/cmd/ostracon/commands/reset.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/line/ostracon/node"
+
 	"github.com/spf13/cobra"
 
 	"github.com/line/ostracon/libs/log"
@@ -81,9 +83,19 @@ func resetPrivValidator(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
-	return resetFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile(),
-		config.PrivValidatorKeyType(), logger)
+	if config.PrivValidatorListenAddr != "" {
+		// If an address is provided, listen on the socket for a connection from an external signing process.
+		_, err = node.ObtainRemoteSignerPubKeyInformally(config.PrivValidatorListenAddr, chainID, logger)
+	} else {
+		err = resetFilePV(config.PrivValidatorKeyFile(), config.PrivValidatorStateFile(),
+			config.PrivValidatorKeyType(), logger)
+	}
 
+	if err == nil {
+		config.Save()
+	}
+
+	return err
 }
 
 // resetAll removes address book files plus all data, and resets the privValdiator data.

--- a/cmd/ostracon/commands/reset.go
+++ b/cmd/ostracon/commands/reset.go
@@ -31,7 +31,7 @@ var ResetStateCmd = &cobra.Command{
 	Short:  "Remove all the data and WAL",
 	PreRun: deprecateSnakeCase,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		config, err = ParseConfig()
+		config, _, err = ParseConfig()
 		if err != nil {
 			return err
 		}
@@ -60,7 +60,7 @@ var ResetPrivValidatorCmd = &cobra.Command{
 // XXX: this is totally unsafe.
 // it's only suitable for testnets.
 func resetAllCmd(cmd *cobra.Command, args []string) (err error) {
-	config, err = ParseConfig()
+	config, _, err = ParseConfig()
 	if err != nil {
 		return err
 	}
@@ -78,7 +78,7 @@ func resetAllCmd(cmd *cobra.Command, args []string) (err error) {
 // XXX: this is totally unsafe.
 // it's only suitable for testnets.
 func resetPrivValidator(cmd *cobra.Command, args []string) (err error) {
-	config, err = ParseConfig()
+	config, _, err = ParseConfig()
 	if err != nil {
 		return err
 	}

--- a/cmd/ostracon/commands/reset_test.go
+++ b/cmd/ostracon/commands/reset_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/line/ostracon/privval"
 )
 
-func setupEnv(t *testing.T) {
+func setupEnv(t *testing.T) string {
 	rootDir := t.TempDir()
 	viper.SetEnvPrefix("OC")
 	require.NoError(t, viper.BindEnv("HOME"))
 	require.NoError(t, os.Setenv("OC_HOME", rootDir))
+	return rootDir
 }
 
 func TestResetAllCmd(t *testing.T) {

--- a/cmd/ostracon/main.go
+++ b/cmd/ostracon/main.go
@@ -40,7 +40,7 @@ func main() {
 	//	* Provide their own DB implementation
 	// can copy this file and use something other than the
 	// DefaultNewNode function
-	nodeFunc := nm.DefaultNewNode
+	nodeFunc := nm.NewOstraconNode
 
 	// Create & start node
 	rootCmd.AddCommand(cmd.NewInitCmd())

--- a/config/config.go
+++ b/config/config.go
@@ -9,8 +9,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/line/ostracon/privval"
 	"github.com/line/tm-db/v2/metadb"
+
+	"github.com/line/ostracon/privval"
 )
 
 const (
@@ -146,6 +147,14 @@ func (cfg *Config) ValidateBasic() error {
 		return fmt.Errorf("error in [instrumentation] section: %w", err)
 	}
 	return nil
+}
+
+func (cfg *Config) Save() {
+	cfg.SaveAs(filepath.Join(cfg.RootDir, defaultConfigFilePath))
+}
+
+func (cfg *Config) SaveAs(file string) {
+	WriteConfigFile(file, cfg)
 }
 
 //-----------------------------------------------------------------------------

--- a/config/config.go
+++ b/config/config.go
@@ -149,8 +149,12 @@ func (cfg *Config) ValidateBasic() error {
 	return nil
 }
 
+func (cfg *Config) Path() string {
+	return filepath.Join(cfg.RootDir, defaultConfigFilePath)
+}
+
 func (cfg *Config) Save() {
-	cfg.SaveAs(filepath.Join(cfg.RootDir, defaultConfigFilePath))
+	cfg.SaveAs(cfg.Path())
 }
 
 func (cfg *Config) SaveAs(file string) {

--- a/config/toml.go
+++ b/config/toml.go
@@ -29,8 +29,8 @@ func init() {
 /****** these are for production settings ***********/
 
 // EnsureRoot creates the root, config, and data directories if they don't exist,
-// and panics if it fails.
-func EnsureRoot(rootDir string) {
+// and panics if it fails. This function returns true when a new configuration file with default settings is created.
+func EnsureRoot(rootDir string) bool {
 	if err := tmos.EnsureDir(rootDir, DefaultDirPerm); err != nil {
 		panic(err.Error())
 	}
@@ -46,7 +46,9 @@ func EnsureRoot(rootDir string) {
 	// Write default config file if missing.
 	if !tmos.FileExists(configFilePath) {
 		writeDefaultConfigFile(configFilePath)
+		return true
 	}
+	return false
 }
 
 // XXX: this func should probably be called by cmd/ostracon/commands/init.go

--- a/node/node.go
+++ b/node/node.go
@@ -730,7 +730,7 @@ func NewNode(config *cfg.Config,
 	// external signing process.
 	if config.PrivValidatorListenAddr != "" {
 		// FIXME: we should start services inside OnStart
-		privValidator, err = createAndStartPrivValidatorSocketClient(config.PrivValidatorListenAddr, genDoc.ChainID, logger)
+		privValidator, err = CreateAndStartPrivValidatorSocketClient(config.PrivValidatorListenAddr, genDoc.ChainID, logger)
 		if err != nil {
 			return nil, fmt.Errorf("error with private validator socket client: %w", err)
 		}
@@ -1438,7 +1438,7 @@ func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) error {
 	return nil
 }
 
-func createAndStartPrivValidatorSocketClient(
+func CreateAndStartPrivValidatorSocketClient(
 	listenAddr,
 	chainID string,
 	logger log.Logger,

--- a/privval/signer_listener_endpoint.go
+++ b/privval/signer_listener_endpoint.go
@@ -156,11 +156,12 @@ func (sl *SignerListenerEndpoint) acceptNewConnection() (net.Conn, error) {
 	}
 
 	// wait for a new conn
-	sl.Logger.Info("SignerListener: Listening for new connection")
+	sl.Logger.Info(fmt.Sprintf("SignerListener: Listening for new connection: %s", sl.listener.Addr()))
 	conn, err := sl.listener.Accept()
 	if err != nil {
 		return nil, err
 	}
+	sl.Logger.Info(fmt.Sprintf("SignerListener: Accept new connection from: %s -> %s", conn.RemoteAddr(), conn.LocalAddr()))
 
 	return conn, nil
 }

--- a/privval/signer_listener_endpoint.go
+++ b/privval/signer_listener_endpoint.go
@@ -161,7 +161,9 @@ func (sl *SignerListenerEndpoint) acceptNewConnection() (net.Conn, error) {
 	if err != nil {
 		return nil, err
 	}
-	sl.Logger.Info(fmt.Sprintf("SignerListener: Accept new connection from: %s -> %s", conn.RemoteAddr(), conn.LocalAddr()))
+	sl.Logger.Info(fmt.Sprintf(
+		"SignerListener: Accept new connection from: %s -> %s",
+		conn.RemoteAddr(), conn.LocalAddr()))
 
 	return conn, nil
 }

--- a/test/kms/main.go
+++ b/test/kms/main.go
@@ -26,13 +26,13 @@ const VrfOutputSize = 64
 func main() {
 	logger := log.NewOCLogger(log.NewSyncWriter(os.Stdout))
 
-	chainId := "test-chain"
+	chainID := "test-chain"
 	protocol, address := tmnet.ProtocolAndAddress("tcp://0.0.0.0:45666")
 	ln, err := net.Listen(protocol, address)
 	NoError(err)
 	listener := privval.NewTCPListener(ln, ed25519.GenPrivKeyFromSecret([]byte("🏺")))
 	endpoint := privval.NewSignerListenerEndpoint(logger, listener)
-	client, err := privval.NewSignerClient(endpoint, chainId)
+	client, err := privval.NewSignerClient(endpoint, chainID)
 	NoError(err)
 
 	// Ping
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	// SignVote
-	blockId := types.BlockID{
+	blockID := types.BlockID{
 		Hash: make([]byte, 32),
 		PartSetHeader: types.PartSetHeader{
 			Total: 10,
@@ -62,14 +62,14 @@ func main() {
 		Type:             types2.PrevoteType,
 		Height:           1,
 		Round:            0,
-		BlockID:          blockId,
+		BlockID:          blockID,
 		Timestamp:        time.Now(),
 		ValidatorAddress: pubKey.Address(),
 		ValidatorIndex:   0,
 		Signature:        nil,
 	}
 	pv := vote.ToProto()
-	err = client.SignVote(chainId, pv)
+	err = client.SignVote(chainID, pv)
 	NoError(err)
 	logger.Info("✅ SignVote: call")
 	if len(pv.Signature) != ed25519.SignatureSize {
@@ -77,9 +77,9 @@ func main() {
 	} else {
 		logger.Info(fmt.Sprintf("✅ SignVote: signature size = %d", len(pv.Signature)))
 	}
-	bytes := types.VoteSignBytes(chainId, pv)
+	bytes := types.VoteSignBytes(chainID, pv)
 	if !pubKey.VerifySignature(bytes, pv.Signature) {
-		logger.Error(fmt.Sprintf("❌ SignVote: signature verification"))
+		logger.Error("❌ SignVote: signature verification")
 	} else {
 		logger.Info("✅ SignVote: signature verification")
 	}
@@ -90,12 +90,12 @@ func main() {
 		Height:    1,
 		Round:     0,
 		POLRound:  -1,
-		BlockID:   blockId,
+		BlockID:   blockID,
 		Timestamp: time.Now(),
 		Signature: nil,
 	}
 	pp := proposal.ToProto()
-	err = client.SignProposal(chainId, pp)
+	err = client.SignProposal(chainID, pp)
 	NoError(err)
 	logger.Info("✅ SignProposal: call")
 	if len(pp.Signature) != ed25519.SignatureSize {
@@ -103,9 +103,9 @@ func main() {
 	} else {
 		logger.Info(fmt.Sprintf("✅ SignProposal: signature size = %d", len(pp.Signature)))
 	}
-	bytes = types.ProposalSignBytes(chainId, pp)
+	bytes = types.ProposalSignBytes(chainID, pp)
 	if !pubKey.VerifySignature(bytes, pp.Signature) {
-		logger.Error(fmt.Sprintf("❌ SignProposal: signature verification"))
+		logger.Error("❌ SignProposal: signature verification")
 	} else {
 		logger.Info("✅ SignProposal: signature verification")
 	}

--- a/test/kms/main.go
+++ b/test/kms/main.go
@@ -1,5 +1,5 @@
 // This program tests that SignerClient can connect to KMS and make API calls.
-// To test, address the KMS connection to port 45666 on the machine running this program and run the following:
+// To test, address the KMS connection to port 26659 on the machine running this program and run the following:
 //
 // $ cd test/kms
 // $ go run -tags libsodium .
@@ -27,7 +27,7 @@ func main() {
 	logger := log.NewOCLogger(log.NewSyncWriter(os.Stdout))
 
 	chainID := "test-chain"
-	protocol, address := tmnet.ProtocolAndAddress("tcp://0.0.0.0:45666")
+	protocol, address := tmnet.ProtocolAndAddress("tcp://0.0.0.0:26659")
 	ln, err := net.Listen(protocol, address)
 	NoError(err)
 	listener := privval.NewTCPListener(ln, ed25519.GenPrivKeyFromSecret([]byte("🏺")))

--- a/test/kms/main.go
+++ b/test/kms/main.go
@@ -8,15 +8,16 @@ package main
 
 import (
 	"fmt"
+	"net"
+	"os"
+	"time"
+
 	"github.com/line/ostracon/crypto/ed25519"
 	"github.com/line/ostracon/libs/log"
 	tmnet "github.com/line/ostracon/libs/net"
 	"github.com/line/ostracon/privval"
 	types2 "github.com/line/ostracon/proto/ostracon/types"
 	"github.com/line/ostracon/types"
-	"net"
-	"os"
-	"time"
 )
 
 const VrfProofSize = 80
@@ -29,7 +30,7 @@ func main() {
 	protocol, address := tmnet.ProtocolAndAddress("tcp://0.0.0.0:45666")
 	ln, err := net.Listen(protocol, address)
 	NoError(err)
-	listener := privval.NewTCPListener(ln, ed25519.GenPrivKey())
+	listener := privval.NewTCPListener(ln, ed25519.GenPrivKeyFromSecret([]byte("🏺")))
 	endpoint := privval.NewSignerListenerEndpoint(logger, listener)
 	client, err := privval.NewSignerClient(endpoint, chainId)
 	NoError(err)

--- a/test/kms/main.go
+++ b/test/kms/main.go
@@ -1,0 +1,138 @@
+// This program tests that SignerClient can connect to KMS and make API calls.
+// To test, address the KMS connection to port 45666 on the machine running this program and run the following:
+//
+// $ cd test/kms
+// $ go run -tags libsodium .
+//
+package main
+
+import (
+	"fmt"
+	"github.com/line/ostracon/crypto/ed25519"
+	"github.com/line/ostracon/libs/log"
+	tmnet "github.com/line/ostracon/libs/net"
+	"github.com/line/ostracon/privval"
+	types2 "github.com/line/ostracon/proto/ostracon/types"
+	"github.com/line/ostracon/types"
+	"net"
+	"os"
+	"time"
+)
+
+const VrfProofSize = 80
+const VrfOutputSize = 64
+
+func main() {
+	logger := log.NewOCLogger(log.NewSyncWriter(os.Stdout))
+
+	chainId := "test-chain"
+	protocol, address := tmnet.ProtocolAndAddress("tcp://0.0.0.0:45666")
+	ln, err := net.Listen(protocol, address)
+	NoError(err)
+	listener := privval.NewTCPListener(ln, ed25519.GenPrivKey())
+	endpoint := privval.NewSignerListenerEndpoint(logger, listener)
+	client, err := privval.NewSignerClient(endpoint, chainId)
+	NoError(err)
+
+	// Ping
+	err = client.Ping()
+	NoError(err)
+	logger.Info("✅ Ping: call")
+
+	// PubKey
+	pubKey, err := client.GetPubKey()
+	NoError(err)
+	logger.Info("✅ PubKey: call")
+	if len(pubKey.Bytes()) != ed25519.PubKeySize {
+		logger.Error(fmt.Sprintf("❌ PubKey: public key size = %d != %d", len(pubKey.Bytes()), ed25519.PubKeySize))
+	} else {
+		logger.Info(fmt.Sprintf("✅ PubKey: public key size = %d", len(pubKey.Bytes())))
+	}
+
+	// SignVote
+	blockId := types.BlockID{
+		Hash: make([]byte, 32),
+		PartSetHeader: types.PartSetHeader{
+			Total: 10,
+			Hash:  make([]byte, 32),
+		},
+	}
+	vote := types.Vote{
+		Type:             types2.PrevoteType,
+		Height:           1,
+		Round:            0,
+		BlockID:          blockId,
+		Timestamp:        time.Now(),
+		ValidatorAddress: pubKey.Address(),
+		ValidatorIndex:   0,
+		Signature:        nil,
+	}
+	pv := vote.ToProto()
+	err = client.SignVote(chainId, pv)
+	NoError(err)
+	logger.Info("✅ SignVote: call")
+	if len(pv.Signature) != ed25519.SignatureSize {
+		logger.Error(fmt.Sprintf("❌ SignVote: signature size = %d != %d", len(pv.Signature), ed25519.SignatureSize))
+	} else {
+		logger.Info(fmt.Sprintf("✅ SignVote: signature size = %d", len(pv.Signature)))
+	}
+	bytes := types.VoteSignBytes(chainId, pv)
+	if !pubKey.VerifySignature(bytes, pv.Signature) {
+		logger.Error(fmt.Sprintf("❌ SignVote: signature verification"))
+	} else {
+		logger.Info("✅ SignVote: signature verification")
+	}
+
+	// SignProposal
+	proposal := types.Proposal{
+		Type:      types2.ProposalType,
+		Height:    1,
+		Round:     0,
+		POLRound:  -1,
+		BlockID:   blockId,
+		Timestamp: time.Now(),
+		Signature: nil,
+	}
+	pp := proposal.ToProto()
+	err = client.SignProposal(chainId, pp)
+	NoError(err)
+	logger.Info("✅ SignProposal: call")
+	if len(pp.Signature) != ed25519.SignatureSize {
+		logger.Error(fmt.Sprintf("❌ SignProposal: signature size = %d != %d", len(pp.Signature), ed25519.SignatureSize))
+	} else {
+		logger.Info(fmt.Sprintf("✅ SignProposal: signature size = %d", len(pp.Signature)))
+	}
+	bytes = types.ProposalSignBytes(chainId, pp)
+	if !pubKey.VerifySignature(bytes, pp.Signature) {
+		logger.Error(fmt.Sprintf("❌ SignProposal: signature verification"))
+	} else {
+		logger.Info("✅ SignProposal: signature verification")
+	}
+
+	// VRFProof
+	message := []byte("hello, world")
+	proof, err := client.GenerateVRFProof(message)
+	NoError(err)
+	logger.Info("✅ VRFProof: call")
+	if len(proof) != VrfProofSize {
+		logger.Error(fmt.Sprintf("❌ VRFProof: proof size = %d != %d", len(proof), VrfProofSize))
+	} else {
+		logger.Info(fmt.Sprintf("✅ VRFProof: proof size = %d", len(proof)))
+	}
+	output, err := pubKey.VRFVerify(proof, message)
+	NoError(err)
+	logger.Info("✅ VRFProof: proof verification")
+	if len(output) != VrfOutputSize {
+		logger.Error(fmt.Sprintf("❌ VRFProof: output size = %d != %d", len(output), VrfOutputSize))
+	} else {
+		logger.Info(fmt.Sprintf("✅ VRFProof: output size = %d", len(output)))
+	}
+
+	logger.Info("All tests finished")
+}
+
+func NoError(err error) {
+	if err != nil {
+		panic(fmt.Sprintf("❌ %v", err))
+	}
+}

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -763,7 +763,7 @@ func NewNode(config *cfg.Config,
 	// external signing process.
 	if config.PrivValidatorListenAddr != "" {
 		// FIXME: we should start services inside OnStart
-		privValidator, err = CreateAndStartPrivValidatorSocketClient(config.PrivValidatorListenAddr, genDoc.ChainID, logger)
+		privValidator, err = createAndStartPrivValidatorSocketClient(config.PrivValidatorListenAddr, genDoc.ChainID, logger)
 		if err != nil {
 			return nil, fmt.Errorf("error with private validator socket client: %w", err)
 		}
@@ -1447,7 +1447,7 @@ func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) {
 	}
 }
 
-func CreateAndStartPrivValidatorSocketClient(
+func createAndStartPrivValidatorSocketClient(
 	listenAddr,
 	chainID string,
 	logger log.Logger,

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -763,7 +763,7 @@ func NewNode(config *cfg.Config,
 	// external signing process.
 	if config.PrivValidatorListenAddr != "" {
 		// FIXME: we should start services inside OnStart
-		privValidator, err = createAndStartPrivValidatorSocketClient(config.PrivValidatorListenAddr, genDoc.ChainID, logger)
+		privValidator, err = CreateAndStartPrivValidatorSocketClient(config.PrivValidatorListenAddr, genDoc.ChainID, logger)
 		if err != nil {
 			return nil, fmt.Errorf("error with private validator socket client: %w", err)
 		}
@@ -1447,7 +1447,7 @@ func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) {
 	}
 }
 
-func createAndStartPrivValidatorSocketClient(
+func CreateAndStartPrivValidatorSocketClient(
 	listenAddr,
 	chainID string,
 	logger log.Logger,


### PR DESCRIPTION
## Description

This PR enables the use of a secure KMS (Key Management System) from Ostracon.

Currently, the key pairs used by Ostracon for agreements are stored locally. But Ostracon nodes are at risk of having their private keys stolen when a malicious attacker breaks into the system since they must accept inbound connections from the Internet.

For more mission-critical applications, such as finance, the node storing the private key must be independent of the Ostracon agreement node, placed behind a firewall, and able to connect to solutions using an HSM (Hardware Security Module) or our SGX solution.

Tendermint, a fork of Ostracon, has the ability to connect to [`tmkms`](https://github.com/iqlusioninc/tmkms), but some of the functionality wasn't sufficient for use from the CLI. Therefore, this PR contains CLI fixes in addition to the program for integration test with KMS.

* `ostracon init` : Added `--priv_validator_laddr` option. This stores the KSM public key in `genesis.json` instead of a locally auto-generated key pair. Also, the settings of KMS connection settings are stored in `config.toml` and can be used in subsequent CLI runs without the option.
* `ostracon run` : Removed the behavior of referencing local key pair when using `--priv_validator_laddr` option.
* `ostracon show-validator` : Changed to get and display KSM public key when using `--priv_validator_laddr` option.
* `ostracon unsafe-reset-priv-validator` : Changed to be similar to the `init` behavior.
