### PR TITLE
Remove the check  if binary is for amd64

### DIFF
--- a/networks/local/localnode/wrapper.sh
+++ b/networks/local/localnode/wrapper.sh
@@ -17,11 +17,6 @@ elif ! [ -x "${BINARY}" ]; then
 	echo "The binary $(basename "${BINARY}") is not executable."
 	exit 1
 fi
-BINARY_CHECK="$(file "$BINARY" | grep 'ELF 64-bit LSB executable, x86-64')"
-if [ -z "${BINARY_CHECK}" ]; then
-	echo "Binary needs to be OS linux, ARCH amd64"
-	exit 1
-fi
 
 ##
 ## Run binary with all parameters


### PR DESCRIPTION
## Description
This PR enables to run [Localnet(4 nodes) with Docker](https://github.com/line/ostracon#localnet4-nodes-with-docker) on apple M1 chip.

This PR contains the following changes:
- Remove the check  if binary is for amd64

Closes: #424 

