### PR TITLE
doesn't support linux/arm(32bit) 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,6 @@ jobs:
             gcc: "aarch64-linux-gnu-gcc"
             package: "g++-aarch64-linux-gnu"
             host: "aarch64-linux-gnu"
-          - goarch: "arm"
-            gcc: "arm-linux-gnueabi-gcc"
-            package: "g++-arm-linux-gnueabi"
-            host: "arm-linux-gnueabi"
     timeout-minutes: 5
     steps:
       - run: sudo apt update && sudo apt install -y ${{ matrix.package }} qemu-user-binfmt


### PR DESCRIPTION
## Description

This PR doesn't support `linux/arm`(32bit), continued support for `linux/amd64` and `linux/arm64`

This PR contains the following changes

- remove arm(32bit) test in .github/workflow/build.yml