### PR TITLE
Change PubKey/PrivKey prefixes of "ostracon/" to "tendermint/" for compatibility (#445)

### DIFF
--- a/config/toml.go
+++ b/config/toml.go
@@ -608,7 +608,7 @@ var testGenesisFmt = `{
   "validators": [
     {
       "pub_key": {
-        "type": "ostracon/PubKeyEd25519",
+        "type": "tendermint/PubKeyEd25519",
         "value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="
       },
       "power": "10",
@@ -626,18 +626,18 @@ var testGenesisFmt = `{
 var testPrivValidatorKey = `{
   "address": "A3258DCBF45DCA0DF052981870F2D1441A36D145",
   "pub_key": {
-    "type": "ostracon/PubKeyEd25519",
+    "type": "tendermint/PubKeyEd25519",
     "value": "AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="
   },
   "priv_key": {
-    "type": "ostracon/PrivKeyEd25519",
+    "type": "tendermint/PrivKeyEd25519",
     "value": "EVkqJO/jIXp3rkASXfh9YnyToYXRXhBr6g9cQVxPFnQBP/5povV4HTjvsy530kybxKHwEi85iU8YL0qQhSYVoQ=="
   }
 }`
 
 var testNodeKey = `{
   "priv_key": {
-    "type": "ostracon/PrivKeyEd25519",
+    "type": "tendermint/PrivKeyEd25519",
     "value": "hICuZLlVwHdzz6pAQOKk07MFn3Hze1EwwTUUhEDIdti9a1cQLR5Co/lxAzeGcyPWS/LuEr7qbgHmDUJT/nxx+Q=="
   }
 }`

--- a/crypto/ed25519/ed25519.go
+++ b/crypto/ed25519/ed25519.go
@@ -20,8 +20,8 @@ import (
 var _ crypto.PrivKey = PrivKey{}
 
 const (
-	PrivKeyName = "ostracon/PrivKeyEd25519"
-	PubKeyName  = "ostracon/PubKeyEd25519"
+	PrivKeyName = "tendermint/PrivKeyEd25519"
+	PubKeyName  = "tendermint/PubKeyEd25519"
 	// PubKeySize is is the size, in bytes, of public keys as used in this package.
 	PubKeySize = 32
 	// PrivateKeySize is the size, in bytes, of private keys as used in this package.

--- a/crypto/secp256k1/secp256k1.go
+++ b/crypto/secp256k1/secp256k1.go
@@ -17,8 +17,8 @@ import (
 
 //-------------------------------------
 const (
-	PrivKeyName = "ostracon/PrivKeySecp256k1"
-	PubKeyName  = "ostracon/PubKeySecp256k1"
+	PrivKeyName = "tendermint/PrivKeySecp256k1"
+	PubKeyName  = "tendermint/PubKeySecp256k1"
 
 	KeyType     = "secp256k1"
 	PrivKeySize = 32

--- a/crypto/sr25519/encoding.go
+++ b/crypto/sr25519/encoding.go
@@ -8,8 +8,8 @@ import (
 var _ crypto.PrivKey = PrivKey{}
 
 const (
-	PrivKeyName = "ostracon/PrivKeySr25519"
-	PubKeyName  = "ostracon/PubKeySr25519"
+	PrivKeyName = "tendermint/PrivKeySr25519"
+	PubKeyName  = "tendermint/PubKeySr25519"
 
 	// SignatureSize is the size of an Edwards25519 signature. Namely the size of a compressed
 	// Sr25519 point, and a field element. Both of which are 32 bytes.

--- a/rpc/openapi/openapi.yaml
+++ b/rpc/openapi/openapi.yaml
@@ -1254,7 +1254,7 @@ components:
       properties:
         type:
           type: string
-          example: "ostracon/PubKeyEd25519"
+          example: "tendermint/PubKeyEd25519"
         value:
           type: string
           example: "A6DoBUypNtUAyEHWtQ9bFjfNg8Bo9CrnkUGl6k6OHN4="
@@ -1698,7 +1698,7 @@ components:
                     properties:
                       type:
                         type: string
-                        example: "ostracon/PubKeyEd25519"
+                        example: "tendermint/PubKeyEd25519"
                       value:
                         type: string
                         example: "9tK9IT+FPdf2qm+5c2qaxi10sWP+3erWTKgftn2PaQM="
@@ -1857,7 +1857,7 @@ components:
                         properties:
                           type:
                             type: string
-                            example: "ostracon/PubKeyEd25519"
+                            example: "tendermint/PubKeyEd25519"
                           value:
                             type: string
                             example: "cOQZvh/h9ZioSeUMZB/1Vy1Xo5x2sjrVjlE/qHnYifM="
@@ -2028,7 +2028,7 @@ components:
                     - "value"
                   properties:
                     type:
-                      example: "ostracon/PubKeyEd25519"
+                      example: "tendermint/PubKeyEd25519"
                     value:
                       type: "string"
                       example: "VNMNfw7mrQBSpEvCtA9ykOe6BoR00RM9b/a9v3vXZhY="
@@ -2803,7 +2803,7 @@ components:
           properties:
             type:
               type: string
-              example: "ostracon/PubKeyEd25519"
+              example: "tendermint/PubKeyEd25519"
             value:
               type: string
               example: "9tK9IT+FPdf2qm+5c2qaxi10sWP+3erWTKgftn2PaQM="

--- a/tools/tm-signer-harness/internal/test_harness_test.go
+++ b/tools/tm-signer-harness/internal/test_harness_test.go
@@ -21,11 +21,11 @@ const (
 	keyFileContents = `{
 	"address": "D08FCA3BA74CF17CBFC15E64F9505302BB0E2748",
 	"pub_key": {
-		"type": "ostracon/PubKeyEd25519",
+		"type": "tendermint/PubKeyEd25519",
 		"value": "ZCsuTjaczEyon70nmKxwvwu+jqrbq5OH3yQjcK0SFxc="
 		},
 	"priv_key": {
-		"type": "ostracon/PrivKeyEd25519",
+		"type": "tendermint/PrivKeyEd25519",
 		"value": "8O39AkQsoe1sBQwud/Kdul8lg8K9SFsql9aZvwXQSt1kKy5ONpzMTKifvSeYrHC/C76Oqturk4ffJCNwrRIXFw=="
 	}
 }`
@@ -61,7 +61,7 @@ const (
 		{
 		"address": "D08FCA3BA74CF17CBFC15E64F9505302BB0E2748",
 		"pub_key": {
-			"type": "ostracon/PubKeyEd25519",
+			"type": "tendermint/PubKeyEd25519",
 			"value": "ZCsuTjaczEyon70nmKxwvwu+jqrbq5OH3yQjcK0SFxc="
 		},
 		"power": "10",

--- a/types/genesis_test.go
+++ b/types/genesis_test.go
@@ -29,7 +29,7 @@ func TestGenesisBad(t *testing.T) {
 		[]byte(
 			`{"validators":[` +
 				`{"pub_key":{` +
-				`"type":"ostracon/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="` +
+				`"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="` +
 				`},"power":"10","name":""}` +
 				`]}`,
 		),
@@ -37,7 +37,7 @@ func TestGenesisBad(t *testing.T) {
 		[]byte(
 			`{"chain_id": "Lorem ipsum dolor sit amet, consectetuer adipiscing", "validators": [` +
 				`{"pub_key":{` +
-				`"type":"ostracon/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="` +
+				`"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="` +
 				`},"power":"10","name":""}` +
 				`]}`,
 		),
@@ -45,7 +45,7 @@ func TestGenesisBad(t *testing.T) {
 		[]byte(
 			`{"chain_id":"mychain", "validators":[` +
 				`{"address": "A", "pub_key":{` +
-				`"type":"ostracon/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="` +
+				`"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="` +
 				`},"power":"10","name":""}` +
 				`]}`,
 		),
@@ -53,7 +53,7 @@ func TestGenesisBad(t *testing.T) {
 		[]byte(
 			`{"chain_id":"mychain", "validators":[` +
 				`{"pub_key":{` +
-				`"type":"ostracon/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="` +
+				`"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="` +
 				`},"power":"10","name":""}], ` +
 				`"voter_params":{"voter_election_threshold":"1"}` +
 				`}`,
@@ -75,7 +75,7 @@ func TestGenesisGood(t *testing.T) {
 			"initial_height": "1000",
 			"consensus_params": null,
 			"validators": [{
-				"pub_key":{"type":"ostracon/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="},
+				"pub_key":{"type":"tendermint/PubKeyEd25519","value":"AT/+aaL1eB0477Mud9JMm8Sh8BIvOYlPGC9KkIUmFaE="},
 				"power":"10",
 				"name":""
 			}],


### PR DESCRIPTION
## Description

This PR changes the name of public and private key prefixes `ostracon/` to `tendermint/` for compatibility with Cosmos assets.

1. The private key may remain "ostracon/PrivKeyXxx" since it's never exposed to the outside world. However, it makes no sense to keep the ostracon prefix until the key pair names are asymmetric, so it's modified with "tendermint/PrivKeyXxx"
2. BLS12 and Composite key types are not compatible rather than current Cosmos assets to begin with.  To make this clear, these Ostracon-specific prefixes are left as "ostracon/". If the Cosmos assets will support the Ostracon specification, they would adopt the `ostracon/` prefix :)

Closes: #445 

