### PR TITLE
Fix the thread-unsafe of PeerState logging

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1080,6 +1080,10 @@ func (ps *PeerState) SetHasProposalBlockPart(height int64, round int32, index in
 func (ps *PeerState) PickSendVote(votes types.VoteSetReader) bool {
 	if vote, ok := ps.PickVoteToSend(votes); ok {
 		msg := &VoteMessage{vote}
+		// Remove the logging `PeerState`
+		// See: https://github.com/line/ostracon/issues/457
+		// See: https://github.com/tendermint/tendermint/discussions/9353
+		// ps.logger.Debug("Sending vote message", "ps", ps, "vote", vote)
 		ps.logger.Debug("Sending vote message", "vote", vote)
 		if ps.peer.Send(VoteChannel, MustEncode(msg)) {
 			ps.SetHasVote(vote)

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1080,7 +1080,7 @@ func (ps *PeerState) SetHasProposalBlockPart(height int64, round int32, index in
 func (ps *PeerState) PickSendVote(votes types.VoteSetReader) bool {
 	if vote, ok := ps.PickVoteToSend(votes); ok {
 		msg := &VoteMessage{vote}
-		ps.logger.Debug("Sending vote message", "ps", ps, "vote", vote)
+		ps.logger.Debug("Sending vote message", "vote", vote)
 		if ps.peer.Send(VoteChannel, MustEncode(msg)) {
 			ps.SetHasVote(vote)
 			return true


### PR DESCRIPTION
## Description

I think it seems that `PeerState` logging is not thread-unsafe. I removed it.

I'm also asking `tendermint`.
* https://github.com/tendermint/tendermint/discussions/9353

Relates: #457

