### PR TITLE
Fix the thread-unsafe of PeerState logging (#458)

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -1080,7 +1080,11 @@ func (ps *PeerState) SetHasProposalBlockPart(height int64, round int32, index in
 func (ps *PeerState) PickSendVote(votes types.VoteSetReader) bool {
 	if vote, ok := ps.PickVoteToSend(votes); ok {
 		msg := &VoteMessage{vote}
-		ps.logger.Debug("Sending vote message", "ps", ps, "vote", vote)
+		// Remove the logging `PeerState`
+		// See: https://github.com/line/ostracon/issues/457
+		// See: https://github.com/tendermint/tendermint/discussions/9353
+		// ps.logger.Debug("Sending vote message", "ps", ps, "vote", vote)
+		ps.logger.Debug("Sending vote message", "vote", vote)
 		if ps.peer.Send(VoteChannel, MustEncode(msg)) {
 			ps.SetHasVote(vote)
 			return true


### PR DESCRIPTION
* Fix the thread-unsafe of PeerState logging

* Add the modification information

(cherry picked from commit 38e64c8b7cfb1ff6c2f4d9b5a7988b6de888e5ed)

## Description

_Please add a description of the changes that this PR introduces and the files that
are the most critical to review._ 

Closes: #XXX

