### PR TITLE
Fix Validators of RPC implementation in Ostracon

### DIFF
--- a/light/provider/http/http.go
+++ b/light/provider/http/http.go
@@ -83,7 +83,7 @@ func (p *http) LightBlock(ctx context.Context, height int64) (*types.LightBlock,
 		}
 	}
 
-	valSet, voterSet, err := p.voterSet(ctx, &sh.Height)
+	valSet, voterSet, err := p.validatorSetAndVoterSet(ctx, &sh.Height)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (p *http) ReportEvidence(ctx context.Context, ev types.Evidence) error {
 	return err
 }
 
-func (p *http) voterSet(ctx context.Context, height *int64) (*types.ValidatorSet, *types.VoterSet, error) {
+func (p *http) validatorSetAndVoterSet(ctx context.Context, height *int64) (*types.ValidatorSet, *types.VoterSet, error) {
 	// Since the malicious node could report a massive number of pages, making us
 	// spend a considerable time iterating, we restrict the number of pages here.
 	// => 10000 validators max

--- a/state/export_test.go
+++ b/state/export_test.go
@@ -48,7 +48,7 @@ func SaveValidatorsInfo(
 	proofHash []byte,
 	valSet *types.ValidatorSet,
 ) error {
-	stateStore := dbStore{db}
+	stateStore := dbStore{db: db}
 	if err := db.Set(calcProofHashKey(height-1), proofHash); err != nil {
 		return err
 	}
@@ -56,11 +56,11 @@ func SaveValidatorsInfo(
 }
 
 func SaveVoterParams(db dbm.DB, height int64, params *types.VoterParams) error {
-	stateStore := dbStore{db}
+	stateStore := dbStore{db: db}
 	return stateStore.saveVoterParams(height, params)
 }
 
 func SaveProofHash(db dbm.DB, height int64, proofHash []byte) error {
-	stateStore := dbStore{db}
+	stateStore := dbStore{db: db}
 	return stateStore.saveProofHash(height, proofHash)
 }


### PR DESCRIPTION
## Description

Calling `Validators` of RPC make often an error because Ostracon's saving state process doesn't have locks while saving `Validators`, `VoterParams`, and `ProofHash`. (Tendermint is unnecessary because it's enough to save `Validators` only.)

Closes: https://github.com/line/lbm-sdk/issues/703
* https://github.com/line/lbm-sdk/issues/703#issuecomment-1280187958

Changes:
* Add locks for `save` and `Bootstrap`
* Refactor in a form close to the original(Tendermint)
* Stop replacing a validator with a `voters.Validator` since it's same both `VotingPower`
