### PR TITLE
Avoid panic when addr does not exist in book

### DIFF
--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -229,8 +229,12 @@ func (a *addrBook) RemoveAddress(addr *p2p.NetAddress) {
 func (a *addrBook) IsGood(addr *p2p.NetAddress) bool {
 	a.mtx.Lock()
 	defer a.mtx.Unlock()
+	ka, ok := a.addrLookup[addr.ID]
+	if !ok || ka == nil {
+		return false
+	}
 
-	return a.addrLookup[addr.ID].isOld()
+	return ka.isOld()
 }
 
 // IsBanned returns true if the peer is currently banned


### PR DESCRIPTION
## Description

I think it seems that calling IsGood() function with a non existent address can cause a runtime panic error.
I fixed to avoid them.

## PR Checklist
- [ ] This implementation returns false when Book contains addr and isOld() returns false, and when Book does not contain addr. Does this fulfill IsGood's obligations?