### PR TITLE
fix: Move `types/test_util.go:MakeBlock` into `types/block.go`

### DIFF
--- a/types/block.go
+++ b/types/block.go
@@ -53,6 +53,25 @@ type Block struct {
 	LastCommit *Commit      `json:"last_commit"`
 }
 
+// MakeBlock returns a new block with an empty header, except what can be
+// computed from itself.
+// It populates the same set of fields validated by ValidateBasic.
+func MakeBlock(height int64, txs []Tx, lastCommit *Commit, evidence []Evidence) *Block {
+	block := &Block{
+		Header: Header{
+			Version: tmversion.Consensus{Block: version.BlockProtocol, App: 0},
+			Height:  height,
+		},
+		Data: Data{
+			Txs: txs,
+		},
+		Evidence:   EvidenceData{Evidence: evidence},
+		LastCommit: lastCommit,
+	}
+	block.fillHeader()
+	return block
+}
+
 // ValidateBasic performs basic validation that doesn't involve state data.
 // It checks the internal consistency of the block.
 // Further validation is done using state#ValidateBlock.

--- a/types/test_util.go
+++ b/types/test_util.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	tmproto "github.com/line/ostracon/proto/ostracon/types"
-	tmversion "github.com/line/ostracon/proto/ostracon/version"
-	"github.com/line/ostracon/version"
 )
 
 func MakeCommit(blockID BlockID, height int64, round int32,
@@ -79,23 +77,4 @@ func MakeVote(
 	vote.Signature = v.Signature
 
 	return vote, nil
-}
-
-// MakeBlock returns a new block with an empty header, except what can be
-// computed from itself.
-// It populates the same set of fields validated by ValidateBasic.
-func MakeBlock(height int64, txs []Tx, lastCommit *Commit, evidence []Evidence) *Block {
-	block := &Block{
-		Header: Header{
-			Version: tmversion.Consensus{Block: version.BlockProtocol, App: 0},
-			Height:  height,
-		},
-		Data: Data{
-			Txs: txs,
-		},
-		Evidence:   EvidenceData{Evidence: evidence},
-		LastCommit: lastCommit,
-	}
-	block.fillHeader()
-	return block
 }


### PR DESCRIPTION
## Description

The production code of `types.MakeBlock` is defined in `types/test_util.go`. It is used for `state.MakeBlock` only. I move it into `types/block.go`

