### PR TITLE
Use the value receiver instead of the pointer receiver in Pubkey.Identity()

### DIFF
--- a/crypto/composite/composite.go
+++ b/crypto/composite/composite.go
@@ -46,7 +46,7 @@ func PubKeyFromBytes(bz []byte) PubKey {
 	return PubKey{SignKey: sign, VrfKey: vrf}
 }
 
-func (pk *PubKey) Identity() crypto.PubKey {
+func (pk PubKey) Identity() crypto.PubKey {
 	return pk.VrfKey
 }
 


### PR DESCRIPTION
## Description

Pubkey.Identity() use the value receiver instead of the pointer receiver.
This is recommended because it is used as a getter and not a large struct.