### PR TITLE
Validate proof with ECVRF_decode_proof in vrfEd25519r2ishiguro.ProofToHash()

### DIFF
--- a/crypto/vrf/vrf_r2ishiguro.go
+++ b/crypto/vrf/vrf_r2ishiguro.go
@@ -33,5 +33,10 @@ func (base vrfEd25519r2ishiguro) Verify(publicKey []byte, proof Proof, message [
 }
 
 func (base vrfEd25519r2ishiguro) ProofToHash(proof Proof) (Output, error) {
+	// validate proof with ECVRF_decode_proof
+	_, _, _, err := r2ishiguro.ECVRF_decode_proof(proof)
+	if err != nil {
+		return nil, err
+	}
 	return r2ishiguro.ECVRF_proof2hash(proof), nil
 }

--- a/crypto/vrf/vrf_r2ishiguro_test.go
+++ b/crypto/vrf/vrf_r2ishiguro_test.go
@@ -10,6 +10,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestVrfEd25519r2ishiguro_ProofToHash(t *testing.T) {
+	secret := [SEEDBYTES]byte{}
+	privateKey := ed25519.NewKeyFromSeed(secret[:])
+	message := []byte("hello, world")
+
+	vrfr2ishiguro := newVrfEd25519r2ishiguro()
+
+	t.Run("to hash r2ishiguro proof", func(t *testing.T) {
+		proof, err := vrfr2ishiguro.Prove(privateKey, message)
+		require.NoError(t, err)
+		require.NotNil(t, proof)
+
+		output, err := vrfr2ishiguro.ProofToHash(proof)
+		require.NoError(t, err)
+		require.NotNil(t, output)
+	})
+
+	t.Run("to hash other algo proof", func(t *testing.T) {
+		proof := []byte("proof of test")
+		output, err := vrfr2ishiguro.ProofToHash(proof)
+		require.Error(t, err)
+		require.Nil(t, output)
+	})
+}
+
 func TestProveAndVerifyR2ishiguroByCryptoEd25519(t *testing.T) {
 	secret := [SEEDBYTES]byte{}
 	privateKey := ed25519.NewKeyFromSeed(secret[:])

--- a/crypto/vrf/vrf_r2ishiguro_test.go
+++ b/crypto/vrf/vrf_r2ishiguro_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestVrfEd25519r2ishiguro_ProofToHash(t *testing.T) {
+func TestVrfEd25519R2ishiguro_ProofToHash(t *testing.T) {
 	secret := [SEEDBYTES]byte{}
 	privateKey := ed25519.NewKeyFromSeed(secret[:])
 	message := []byte("hello, world")


### PR DESCRIPTION
## Description

The external function ECVRF_proof2hash() only takes the slice from position 1 to 32 as the hash, but does not check the input vrf proof is valid or not. This implementation violates the ongoing standardization described in section 5.2 of the VRF documentation.
I think it's better to verify the vrf proof before calling r2ishiguro.ECVRF_proof2hash(proof) to keep up with the ongoing standardization.

## PR Check List
- [ ] Is the current test pattern sufficient?
- [ ] Is the ProofToHash error pattern sufficient?