### PR TITLE
Remove sort from proposer's selection algorithm

### DIFF
--- a/libs/rand/sampling.go
+++ b/libs/rand/sampling.go
@@ -17,7 +17,7 @@ type Candidate interface {
 //
 // Inputs:
 // seed - 64bit integer used for random selection.
-// candidates - A set of candidates. The order is disregarded.
+// candidates - A set of candidates. You get different results depending on the order.
 // sampleSize - The number of candidates to select at random.
 // totalPriority - The exact sum of the priorities of each candidate.
 //
@@ -34,9 +34,6 @@ func RandomSamplingWithPriority(
 		thresholds[i] = RandomThreshold(&seed, totalPriority)
 	}
 	s.Slice(thresholds, func(i, j int) bool { return thresholds[i] < thresholds[j] })
-
-	// generates a copy of the set to keep the given array order
-	candidates = sort(candidates)
 
 	// extract candidates with a cumulative priority threshold
 	samples = make([]Candidate, sampleSize)

--- a/libs/rand/sampling.go
+++ b/libs/rand/sampling.go
@@ -93,16 +93,3 @@ func nextRandom(rand *uint64) uint64 {
 	z = (z ^ (z >> 27)) * 0x94d049bb133111eb
 	return z ^ (z >> 31)
 }
-
-// sort candidates in descending priority and ascending nature order
-func sort(candidates []Candidate) []Candidate {
-	temp := make([]Candidate, len(candidates))
-	copy(temp, candidates)
-	s.Slice(temp, func(i, j int) bool {
-		if temp[i].Priority() != temp[j].Priority() {
-			return temp[i].Priority() > temp[j].Priority()
-		}
-		return temp[i].LessThan(temp[j])
-	})
-	return temp
-}


### PR DESCRIPTION
## Description

I assume that the candidate order is already consistent with the other nodes. 
Then the threshold random numbers are already in ascending order and it checks if the random number is between cumulativePriority and cumulativePriority+candidate.Priority() to pick the same candidate.
So we don't use sorting of candidates for optimization.

## PR Check List
- [ ] Is the order of candidates consistent with other nodes?
- [ ] Is this fulfilling the duties of this function?
- [ ] I removed the unused "function:sort", but should I keep it in mind that it will be used in the future?