### PR TITLE
fix: Update the http status code handling on upnp

### DIFF
--- a/p2p/upnp/upnp.go
+++ b/p2p/upnp/upnp.go
@@ -285,7 +285,7 @@ func soapRequest(url, function, message, domain string) (r *http.Response, err e
 	    defer r.Body.Close()
 	}*/
 
-	if r.StatusCode >= 400 {
+	if r.StatusCode != http.StatusOK {
 		// log.Stderr(function, r.StatusCode)
 		err = errors.New("error " + strconv.Itoa(r.StatusCode) + " for " + function)
 		r = nil


### PR DESCRIPTION
## Description

For more strict handling, I modify checking the response code whether `http.StatusOK` or not since UPnP doesn't design the other status code like 30x.
