### PR TITLE
Add error handling in newHashKey

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -26,3 +26,4 @@ ignore:
   - "scripts"
   - "**/*.pb.go"
   - "libs/pubsub/query/query.peg.go"
+  - "libs/std/**/*.go"

--- a/libs/std/crypto/rand/rand.go
+++ b/libs/std/crypto/rand/rand.go
@@ -1,0 +1,11 @@
+package rand
+
+import (
+	crand "crypto/rand"
+)
+
+func Read(b []byte) {
+	if _, err := crand.Read(b); err != nil {
+		panic(err)
+	}
+}

--- a/libs/std/doc.go
+++ b/libs/std/doc.go
@@ -1,0 +1,4 @@
+// The std wraps standard packages that are hard to intentionally cause errors when testing.
+// This package is ignored by codecov, so you need to check if you can ignore it when adding it.
+
+package std

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -5,7 +5,6 @@
 package pex
 
 import (
-	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -20,6 +19,7 @@ import (
 	tmmath "github.com/line/ostracon/libs/math"
 	tmrand "github.com/line/ostracon/libs/rand"
 	"github.com/line/ostracon/libs/service"
+	stdCryptoRand "github.com/line/ostracon/libs/std/crypto/rand"
 	tmsync "github.com/line/ostracon/libs/sync"
 	"github.com/line/ostracon/p2p"
 )
@@ -110,9 +110,7 @@ type addrBook struct {
 
 func newHashKey() []byte {
 	result := make([]byte, highwayhash.Size)
-	if _, err := crand.Read(result); err != nil {
-		panic("failed to create hash key") // codecov:ignore:this
-	}
+	stdCryptoRand.Read(result)
 	return result
 }
 

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -110,7 +110,9 @@ type addrBook struct {
 
 func newHashKey() []byte {
 	result := make([]byte, highwayhash.Size)
-	crand.Read(result) //nolint:errcheck // ignore error
+	if _, err := crand.Read(result); err != nil {
+		panic("failed to create hash key") // codecov:ignore:this
+	}
 	return result
 }
 

--- a/p2p/pex/addrbook.go
+++ b/p2p/pex/addrbook.go
@@ -19,7 +19,7 @@ import (
 	tmmath "github.com/line/ostracon/libs/math"
 	tmrand "github.com/line/ostracon/libs/rand"
 	"github.com/line/ostracon/libs/service"
-	stdCryptoRand "github.com/line/ostracon/libs/std/crypto/rand"
+	stdcrand "github.com/line/ostracon/libs/std/crypto/rand"
 	tmsync "github.com/line/ostracon/libs/sync"
 	"github.com/line/ostracon/p2p"
 )
@@ -110,7 +110,7 @@ type addrBook struct {
 
 func newHashKey() []byte {
 	result := make([]byte, highwayhash.Size)
-	stdCryptoRand.Read(result)
+	stdcrand.Read(result)
 	return result
 }
 


### PR DESCRIPTION
## Description
When calling the function newHashKey() if an error occurs while filling the new key with random data from the defined random source, the created hash key will be zeroed, which means, the content of the slice will be all 0's.

I think it's better to handle errors properly.


