### PR TITLE
Remove unsed the functioin `StateProvider`

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -212,15 +212,6 @@ func CustomReactors(reactors map[string]p2p.Reactor) Option {
 	}
 }
 
-// StateProvider overrides the state provider used by state sync to retrieve trusted app hashes and
-// build a State object for bootstrapping the node.
-// WARNING: this interface is considered unstable and subject to change.
-func StateProvider(stateProvider statesync.StateProvider) Option {
-	return func(n *Node) {
-		n.stateSyncProvider = stateProvider
-	}
-}
-
 //------------------------------------------------------------------------------
 
 // Node is the highest level interface to a full Ostracon node.


### PR DESCRIPTION
## Description

The function `StateProvider()` is used to override the state provider in the state sync case. It is unstable and easy to change, and currently, the function is not used anywhere in the codebase. So I remove the aforementioned function for code maintenance.