### PR TITLE
Add validation of the ValidatorsHash, Round and Proof

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -123,7 +123,8 @@ jobs:
         if: "env.GIT_DIFF != ''"
 
       - name: Build libsodium
-      - run: make libsodium
+        run: make libsodium
+
       - uses: actions/upload-artifact@v3
         with:
           name: libsodium

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,6 +122,13 @@ jobs:
           docker load -i ${{ needs.e2e-build.outputs.CACHE_FILE }}
         if: "env.GIT_DIFF != ''"
 
+      - name: Build libsodium
+      - run: make libsodium
+      - uses: actions/upload-artifact@v3
+        with:
+          name: libsodium
+          path: crypto/vrf/internal/vrf/sodium
+
       - name: Build e2e runner
         working-directory: test/e2e
         run: make runner

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -125,11 +125,6 @@ jobs:
       - name: Build libsodium
         run: make libsodium
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: libsodium
-          path: crypto/vrf/internal/vrf/sodium
-
       - name: Build e2e runner
         working-directory: test/e2e
         run: make runner

--- a/crypto/vrf/README.md
+++ b/crypto/vrf/README.md
@@ -12,7 +12,6 @@ VRF implementation is set by `func init()` with `build` option
 type vrfEd25519 interface {
 	Prove(privateKey []byte, message []byte) (Proof, error)
 	Verify(publicKey []byte, proof Proof, message []byte) (bool, error)
-	ProofLength() int
 	ProofToHash(proof Proof) (Output, error)
 ```
 
@@ -26,17 +25,20 @@ Use `func init()` with `build` option
       * `//go:build libsodium`
       * `// +build !libsodium,!coniks`
       * `func init() { defaultVrf = newVrfEd25519r2ishiguro() }`
+      * `const ProofSize = 81`
       * vrf_r2ishiguro.go
     * (coniks)
       * `//go:build coniks`
       * `// +build coniks`
       * `func init() { defaultVrf = newVrfEd25519coniks() }`
+      * `const ProofSize = 96`
       * vrf_coniks.go
       * vrf_coniks_test.go
     * (libsodium)
       * `//go:build libsodium`
       * `// +build libsodium`
       * `func init() { defaultVrf = newVrfEd25519libsodium() }`
+      * `const ProofSize = int(libsodium.PROOFBYTES)`
       * vrf_libsodium.go
       * vrf_libsodium_test.go
 

--- a/crypto/vrf/README.md
+++ b/crypto/vrf/README.md
@@ -12,6 +12,7 @@ VRF implementation is set by `func init()` with `build` option
 type vrfEd25519 interface {
 	Prove(privateKey []byte, message []byte) (Proof, error)
 	Verify(publicKey []byte, proof Proof, message []byte) (bool, error)
+	ProofLength() int
 	ProofToHash(proof Proof) (Output, error)
 ```
 

--- a/crypto/vrf/internal/vrf/vrf.go
+++ b/crypto/vrf/internal/vrf/vrf.go
@@ -8,6 +8,8 @@ package vrf
 #cgo CFLAGS: -Wall -std=c99
 #cgo darwin,amd64 CFLAGS: -I./sodium/darwin_amd64/include/
 #cgo darwin,amd64 LDFLAGS: -L./sodium/darwin_amd64/lib -lsodium
+#cgo darwin,arm64 CFLAGS: -I./sodium/darwin_arm64/include/
+#cgo darwin,arm64 LDFLAGS: -L./sodium/darwin_arm64/lib -lsodium
 #cgo linux,amd64 CFLAGS: -I./sodium/linux_amd64/include
 #cgo linux,amd64 LDFLAGS: -L./sodium/linux_amd64/lib -lsodium
 #cgo linux,arm64 CFLAGS: -I./sodium/linux_arm64/include

--- a/crypto/vrf/vrf.go
+++ b/crypto/vrf/vrf.go
@@ -16,7 +16,6 @@ type Output []byte
 type vrfEd25519 interface {
 	Prove(privateKey []byte, message []byte) (Proof, error)
 	Verify(publicKey []byte, proof Proof, message []byte) (bool, error)
-	ProofLength() int
 	ProofToHash(proof Proof) (Output, error)
 }
 
@@ -32,10 +31,6 @@ func Prove(privateKey []byte, message []byte) (Proof, error) {
 
 func Verify(publicKey []byte, proof Proof, message []byte) (bool, error) {
 	return defaultVrf.Verify(publicKey, proof, message)
-}
-
-func ProofLength() int {
-	return defaultVrf.ProofLength()
 }
 
 func ProofToHash(proof Proof) (Output, error) {

--- a/crypto/vrf/vrf.go
+++ b/crypto/vrf/vrf.go
@@ -16,6 +16,7 @@ type Output []byte
 type vrfEd25519 interface {
 	Prove(privateKey []byte, message []byte) (Proof, error)
 	Verify(publicKey []byte, proof Proof, message []byte) (bool, error)
+	ProofLength() int
 	ProofToHash(proof Proof) (Output, error)
 }
 
@@ -31,6 +32,10 @@ func Prove(privateKey []byte, message []byte) (Proof, error) {
 
 func Verify(publicKey []byte, proof Proof, message []byte) (bool, error) {
 	return defaultVrf.Verify(publicKey, proof, message)
+}
+
+func ProofLength() int {
+	return defaultVrf.ProofLength()
 }
 
 func ProofToHash(proof Proof) (Output, error) {

--- a/crypto/vrf/vrf_coniks.go
+++ b/crypto/vrf/vrf_coniks.go
@@ -19,7 +19,7 @@ func init() {
 	defaultVrf = newVrfEd25519coniks()
 }
 
-const ConiksProofLength = 96
+const ProofSize = 96
 
 func newVrfEd25519coniks() *vrfEd25519coniks {
 	return &vrfEd25519coniks{nil, nil}
@@ -54,10 +54,6 @@ func (base *vrfEd25519coniks) Verify(publicKey []byte, proof Proof, message []by
 	coniksPubKey := coniks.PublicKey(make([]byte, coniks.PublicKeySize))
 	copy(coniksPubKey, publicKey)
 	return coniksPubKey.Verify(message, base.generatedHash, proof), nil
-}
-
-func (base *vrfEd25519coniks) ProofLength() int {
-	return ConiksProofLength
 }
 
 func (base *vrfEd25519coniks) ProofToHash(proof Proof) (Output, error) {

--- a/crypto/vrf/vrf_coniks.go
+++ b/crypto/vrf/vrf_coniks.go
@@ -19,7 +19,7 @@ func init() {
 	defaultVrf = newVrfEd25519coniks()
 }
 
-const ProofSize = 96
+const ProofSize = coniks.ProofSize
 
 func newVrfEd25519coniks() *vrfEd25519coniks {
 	return &vrfEd25519coniks{nil, nil}

--- a/crypto/vrf/vrf_coniks.go
+++ b/crypto/vrf/vrf_coniks.go
@@ -19,6 +19,8 @@ func init() {
 	defaultVrf = newVrfEd25519coniks()
 }
 
+const ConiksProofLength = 96
+
 func newVrfEd25519coniks() *vrfEd25519coniks {
 	return &vrfEd25519coniks{nil, nil}
 }
@@ -52,6 +54,10 @@ func (base *vrfEd25519coniks) Verify(publicKey []byte, proof Proof, message []by
 	coniksPubKey := coniks.PublicKey(make([]byte, coniks.PublicKeySize))
 	copy(coniksPubKey, publicKey)
 	return coniksPubKey.Verify(message, base.generatedHash, proof), nil
+}
+
+func (base *vrfEd25519coniks) ProofLength() int {
+	return ConiksProofLength
 }
 
 func (base *vrfEd25519coniks) ProofToHash(proof Proof) (Output, error) {

--- a/crypto/vrf/vrf_libsodium.go
+++ b/crypto/vrf/vrf_libsodium.go
@@ -18,6 +18,8 @@ func init() {
 	defaultVrf = newVrfEd25519libsodium()
 }
 
+const LibsodiumProofLength = 80
+
 func newVrfEd25519libsodium() vrfEd25519libsodium {
 	return vrfEd25519libsodium{}
 }
@@ -44,6 +46,10 @@ func (base vrfEd25519libsodium) Verify(publicKey []byte, proof Proof, message []
 		return false, err
 	}
 	return bytes.Compare(op[:], hash) == 0, nil
+}
+
+func (base vrfEd25519libsodium) ProofLength() int {
+	return LibsodiumProofLength
 }
 
 func (base vrfEd25519libsodium) ProofToHash(proof Proof) (Output, error) {

--- a/crypto/vrf/vrf_libsodium.go
+++ b/crypto/vrf/vrf_libsodium.go
@@ -18,7 +18,7 @@ func init() {
 	defaultVrf = newVrfEd25519libsodium()
 }
 
-const LibsodiumProofLength = 80
+const ProofSize = int(libsodium.PROOFBYTES)
 
 func newVrfEd25519libsodium() vrfEd25519libsodium {
 	return vrfEd25519libsodium{}
@@ -46,10 +46,6 @@ func (base vrfEd25519libsodium) Verify(publicKey []byte, proof Proof, message []
 		return false, err
 	}
 	return bytes.Compare(op[:], hash) == 0, nil
-}
-
-func (base vrfEd25519libsodium) ProofLength() int {
-	return LibsodiumProofLength
 }
 
 func (base vrfEd25519libsodium) ProofToHash(proof Proof) (Output, error) {

--- a/crypto/vrf/vrf_r2ishiguro.go
+++ b/crypto/vrf/vrf_r2ishiguro.go
@@ -19,6 +19,8 @@ func init() {
 	}
 }
 
+const R2ishiguroProofLength = 81
+
 func newVrfEd25519r2ishiguro() vrfEd25519r2ishiguro {
 	return vrfEd25519r2ishiguro{}
 }
@@ -30,6 +32,10 @@ func (base vrfEd25519r2ishiguro) Prove(privateKey []byte, message []byte) (Proof
 
 func (base vrfEd25519r2ishiguro) Verify(publicKey []byte, proof Proof, message []byte) (bool, error) {
 	return r2ishiguro.ECVRF_verify(publicKey, proof, message)
+}
+
+func (base vrfEd25519r2ishiguro) ProofLength() int {
+	return R2ishiguroProofLength
 }
 
 func (base vrfEd25519r2ishiguro) ProofToHash(proof Proof) (Output, error) {

--- a/crypto/vrf/vrf_r2ishiguro.go
+++ b/crypto/vrf/vrf_r2ishiguro.go
@@ -19,7 +19,7 @@ func init() {
 	}
 }
 
-const R2ishiguroProofLength = 81
+const ProofSize = 81
 
 func newVrfEd25519r2ishiguro() vrfEd25519r2ishiguro {
 	return vrfEd25519r2ishiguro{}
@@ -32,10 +32,6 @@ func (base vrfEd25519r2ishiguro) Prove(privateKey []byte, message []byte) (Proof
 
 func (base vrfEd25519r2ishiguro) Verify(publicKey []byte, proof Proof, message []byte) (bool, error) {
 	return r2ishiguro.ECVRF_verify(publicKey, proof, message)
-}
-
-func (base vrfEd25519r2ishiguro) ProofLength() int {
-	return R2ishiguroProofLength
 }
 
 func (base vrfEd25519r2ishiguro) ProofToHash(proof Proof) (Output, error) {

--- a/evidence/verify_test.go
+++ b/evidence/verify_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/line/ostracon/light"
 
-	"github.com/coniks-sys/coniks-go/crypto/vrf"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +15,7 @@ import (
 
 	"github.com/line/ostracon/crypto"
 	"github.com/line/ostracon/crypto/tmhash"
+	"github.com/line/ostracon/crypto/vrf"
 	"github.com/line/ostracon/evidence"
 	"github.com/line/ostracon/evidence/mocks"
 	"github.com/line/ostracon/libs/log"
@@ -735,7 +734,7 @@ func makeHeaderRandom(height int64) *types.Header {
 		LastResultsHash:    crypto.CRandBytes(tmhash.Size),
 		EvidenceHash:       crypto.CRandBytes(tmhash.Size),
 		ProposerAddress:    crypto.CRandBytes(crypto.AddressSize),
-		Proof:              crypto.CRandBytes(vrf.ProofSize),
+		Proof:              crypto.CRandBytes(vrf.ProofLength()),
 	}
 }
 

--- a/evidence/verify_test.go
+++ b/evidence/verify_test.go
@@ -734,7 +734,7 @@ func makeHeaderRandom(height int64) *types.Header {
 		LastResultsHash:    crypto.CRandBytes(tmhash.Size),
 		EvidenceHash:       crypto.CRandBytes(tmhash.Size),
 		ProposerAddress:    crypto.CRandBytes(crypto.AddressSize),
-		Proof:              crypto.CRandBytes(vrf.ProofLength()),
+		Proof:              crypto.CRandBytes(vrf.ProofSize),
 	}
 }
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -15,9 +15,9 @@ maverick:
 	go build -o build/maverick -tags libsodium,badgerdb,boltdb,cleveldb,rocksdb ../maverick
 
 generator:
-	go build -o build/generator ./generator
+	go build -o build/generator -tags libsodium ./generator
 
 runner:
-	go build -o build/runner ./runner
+	go build -o build/runner -tags libsodium ./runner
 
 .PHONY: all node docker generator maverick runner

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -7,17 +7,17 @@ docker:
 # order to build a binary with an Ostracon node in it (for built-in
 # ABCI testing).
 node:
-	go build -o build/node -tags libsodium,badgerdb,boltdb,cleveldb,rocksdb ./node
+	go build -o build/node -tags badgerdb,boltdb,cleveldb,rocksdb ./node
 
 # To be used primarily by the e2e docker instance. If you want to produce this binary
 # elsewhere, then run go build in the maverick directory.
 maverick:
-	go build -o build/maverick -tags libsodium,badgerdb,boltdb,cleveldb,rocksdb ../maverick
+	go build -o build/maverick -tags badgerdb,boltdb,cleveldb,rocksdb ../maverick
 
 generator:
-	go build -o build/generator -tags libsodium ./generator
+	go build -o build/generator ./generator
 
 runner:
-	go build -o build/runner -tags libsodium ./runner
+	go build -o build/runner ./runner
 
 .PHONY: all node docker generator maverick runner

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -7,17 +7,17 @@ docker:
 # order to build a binary with an Ostracon node in it (for built-in
 # ABCI testing).
 node:
-	go build -o build/node -tags badgerdb,boltdb,cleveldb,rocksdb ./node
+	go build -o build/node -tags libsodium,badgerdb,boltdb,cleveldb,rocksdb ./node
 
 # To be used primarily by the e2e docker instance. If you want to produce this binary
 # elsewhere, then run go build in the maverick directory.
 maverick:
-	go build -o build/maverick -tags badgerdb,boltdb,cleveldb,rocksdb ../maverick
+	go build -o build/maverick -tags libsodium,badgerdb,boltdb,cleveldb,rocksdb ../maverick
 
 generator:
-	go build -o build/generator ./generator
+	go build -o build/generator -tags libsodium ./generator
 
 runner:
-	go build -o build/runner ./runner
+	go build -o build/runner -tags libsodium ./runner
 
 .PHONY: all node docker generator maverick runner

--- a/test/e2e/runner/test.go
+++ b/test/e2e/runner/test.go
@@ -15,5 +15,5 @@ func Test(testnet *e2e.Testnet) error {
 		return err
 	}
 
-	return execVerbose("go", "test", "-count", "1", "./tests/...")
+	return execVerbose("go", "test", "-count", "1", "-tags", "libsodium", "./tests/...")
 }

--- a/types/block.go
+++ b/types/block.go
@@ -423,9 +423,6 @@ func (h Header) ValidateBasic() error {
 	if len(h.ChainID) > MaxChainIDLen {
 		return fmt.Errorf("chainID is too long; got: %d, max: %d", len(h.ChainID), MaxChainIDLen)
 	}
-	if h.Round < 0 {
-		return errors.New("negative Round")
-	}
 
 	if h.Height < 0 {
 		return errors.New("negative Height")
@@ -456,19 +453,11 @@ func (h Header) ValidateBasic() error {
 		)
 	}
 
-	if err := ValidateProof(h.Proof); err != nil {
-		return fmt.Errorf("wrong Proof: %v", err)
-	}
-
 	// Basic validation of hashes related to application data.
 	// Will validate fully against state in state#ValidateBlock.
 	if err := ValidateHash(h.ValidatorsHash); err != nil {
 		return fmt.Errorf("wrong ValidatorsHash: %v", err)
 	}
-	if err := ValidateHash(h.VotersHash); err != nil {
-		return fmt.Errorf("wrong VotersHash: %v", err)
-	}
-	// TODO When we add `Header.ValidatorsHash` in a future commit, we have to add a similar check here.
 	if err := ValidateHash(h.NextValidatorsHash); err != nil {
 		return fmt.Errorf("wrong NextValidatorsHash: %v", err)
 	}
@@ -478,6 +467,18 @@ func (h Header) ValidateBasic() error {
 	// NOTE: AppHash is arbitrary length
 	if err := ValidateHash(h.LastResultsHash); err != nil {
 		return fmt.Errorf("wrong LastResultsHash: %v", err)
+	}
+
+	if err := ValidateHash(h.VotersHash); err != nil {
+		return fmt.Errorf("wrong VotersHash: %v", err)
+	}
+
+	if h.Round < 0 {
+		return errors.New("negative Round")
+	}
+
+	if err := ValidateProof(h.Proof); err != nil {
+		return fmt.Errorf("wrong Proof: %v", err)
 	}
 
 	return nil

--- a/types/block.go
+++ b/types/block.go
@@ -423,6 +423,9 @@ func (h Header) ValidateBasic() error {
 	if len(h.ChainID) > MaxChainIDLen {
 		return fmt.Errorf("chainID is too long; got: %d, max: %d", len(h.ChainID), MaxChainIDLen)
 	}
+	if h.Round < 0 {
+		return errors.New("negative Round")
+	}
 
 	if h.Height < 0 {
 		return errors.New("negative Height")
@@ -453,8 +456,15 @@ func (h Header) ValidateBasic() error {
 		)
 	}
 
+	if err := ValidateProof(h.Proof); err != nil {
+		return fmt.Errorf("wrong Proof: %v", err)
+	}
+
 	// Basic validation of hashes related to application data.
 	// Will validate fully against state in state#ValidateBlock.
+	if err := ValidateHash(h.ValidatorsHash); err != nil {
+		return fmt.Errorf("wrong ValidatorsHash: %v", err)
+	}
 	if err := ValidateHash(h.VotersHash); err != nil {
 		return fmt.Errorf("wrong VotersHash: %v", err)
 	}

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -644,7 +644,7 @@ func TestHeaderValidateBasic(t *testing.T) {
 			header.Round = -1
 		}, true},
 		{"Invalid Proof", func(header *Header) {
-			header.Proof = make([]byte, vrf.ProofLength()-1)
+			header.Proof = make([]byte, vrf.ProofSize-1)
 		}, true},
 		{"Invalid Validators Hash", func(header *Header) {
 			header.ValidatorsHash = []byte(strings.Repeat("h", invalidHashLength))
@@ -671,7 +671,7 @@ func TestHeaderValidateBasic(t *testing.T) {
 				EvidenceHash:       tmhash.Sum([]byte("evidence_hash")),
 				ProposerAddress:    crypto.AddressHash([]byte("proposer_address")),
 				Round:              1,
-				Proof:              make([]byte, vrf.ProofLength()),
+				Proof:              make([]byte, vrf.ProofSize),
 			}
 			tc.malleateHeader(header)
 			err := header.ValidateBasic()
@@ -1279,7 +1279,7 @@ func makeRandHeader() Header {
 	height := tmrand.Int63()
 	randBytes := tmrand.Bytes(tmhash.Size)
 	randAddress := tmrand.Bytes(crypto.AddressSize)
-	randProof := tmrand.Bytes(vrf.ProofLength())
+	randProof := tmrand.Bytes(vrf.ProofSize)
 	h := Header{
 		Version:            tmversion.Consensus{Block: version.BlockProtocol, App: 1},
 		ChainID:            chainID,

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -1277,6 +1277,7 @@ func makeRandHeader() Header {
 	height := tmrand.Int63()
 	randBytes := tmrand.Bytes(tmhash.Size)
 	randAddress := tmrand.Bytes(crypto.AddressSize)
+	randProof := tmrand.Bytes(vrf.ProofLength())
 	h := Header{
 		Version:            tmversion.Consensus{Block: version.BlockProtocol, App: 1},
 		ChainID:            chainID,
@@ -1294,6 +1295,7 @@ func makeRandHeader() Header {
 
 		EvidenceHash:    randBytes,
 		ProposerAddress: randAddress,
+		Proof:           randProof,
 	}
 
 	return h

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -495,8 +495,6 @@ func TestCommitHash(t *testing.T) {
 	})
 }
 
-// The Proof defined here does not depend on the vrf ProofLength,
-// but it is a fixed value for the purpose of calculating the Hash value.
 func TestHeaderHash(t *testing.T) {
 	testCases := []struct {
 		desc       string
@@ -520,7 +518,9 @@ func TestHeaderHash(t *testing.T) {
 			EvidenceHash:       tmhash.Sum([]byte("evidence_hash")),
 			ProposerAddress:    crypto.AddressHash([]byte("proposer_address")),
 			Round:              1,
-			Proof:              tmhash.Sum([]byte("proof")),
+			// The Proof defined here does not depend on the vrf ProofLength,
+			// but it is a fixed value for the purpose of calculating the Hash value.
+			Proof: tmhash.Sum([]byte("proof")),
 		}, hexBytesFromString("0368E6F15B6B7BC9DC5B10F36F37D6F867E132A22333F083A11290324274E183")},
 		{"nil header yields nil", nil, nil},
 		{"nil VotersHash yields nil", &Header{
@@ -539,7 +539,9 @@ func TestHeaderHash(t *testing.T) {
 			EvidenceHash:       tmhash.Sum([]byte("evidence_hash")),
 			ProposerAddress:    crypto.AddressHash([]byte("proposer_address")),
 			Round:              1,
-			Proof:              tmhash.Sum([]byte("proof")),
+			// The Proof defined here does not depend on the vrf ProofLength,
+			// but it is a fixed value for the purpose of calculating the Hash value.
+			Proof: tmhash.Sum([]byte("proof")),
 		}, nil},
 	}
 	for _, tc := range testCases {

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -638,6 +638,15 @@ func TestHeaderValidateBasic(t *testing.T) {
 		{"Invalid Results Hash", func(header *Header) {
 			header.LastResultsHash = []byte(strings.Repeat("h", invalidHashLength))
 		}, true},
+		{"Negative Round", func(header *Header) {
+			header.Round = -1
+		}, true},
+		{"Invalid Proof", func(header *Header) {
+			header.Proof = make([]byte, vrf.ProofLength()-1)
+		}, true},
+		{"Invalid Validators Hash", func(header *Header) {
+			header.ValidatorsHash = []byte(strings.Repeat("h", invalidHashLength))
+		}, true},
 	}
 	for i, tc := range testCases {
 		tc := tc
@@ -660,7 +669,7 @@ func TestHeaderValidateBasic(t *testing.T) {
 				EvidenceHash:       tmhash.Sum([]byte("evidence_hash")),
 				ProposerAddress:    crypto.AddressHash([]byte("proposer_address")),
 				Round:              1,
-				Proof:              tmhash.Sum([]byte("proof")),
+				Proof:              make([]byte, vrf.ProofLength()),
 			}
 			tc.malleateHeader(header)
 			err := header.ValidateBasic()

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -495,6 +495,8 @@ func TestCommitHash(t *testing.T) {
 	})
 }
 
+// The Proof defined here does not depend on the vrf ProofLength,
+// but it is a fixed value for the purpose of calculating the Hash value.
 func TestHeaderHash(t *testing.T) {
 	testCases := []struct {
 		desc       string

--- a/types/validation.go
+++ b/types/validation.go
@@ -41,11 +41,11 @@ func ValidateHash(h []byte) error {
 }
 
 // ValidateProof returns an error if the proof is not empty, but its
-// size != vrf.ProofLength().
+// size != vrf.ProofSize.
 func ValidateProof(h []byte) error {
-	if len(h) > 0 && len(h) != vrf.ProofLength() {
+	if len(h) > 0 && len(h) != vrf.ProofSize {
 		return fmt.Errorf("expected size to be %d bytes, got %d bytes",
-			vrf.ProofLength(),
+			vrf.ProofSize,
 			len(h),
 		)
 	}

--- a/types/validation.go
+++ b/types/validation.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/line/ostracon/crypto/tmhash"
+	"github.com/line/ostracon/crypto/vrf"
 	tmtime "github.com/line/ostracon/types/time"
 )
 
@@ -33,6 +34,18 @@ func ValidateHash(h []byte) error {
 	if len(h) > 0 && len(h) != tmhash.Size {
 		return fmt.Errorf("expected size to be %d bytes, got %d bytes",
 			tmhash.Size,
+			len(h),
+		)
+	}
+	return nil
+}
+
+// ValidateProof returns an error if the proof is not empty, but its
+// size != vrf.ProofLength().
+func ValidateProof(h []byte) error {
+	if len(h) > 0 && len(h) != vrf.ProofLength() {
+		return fmt.Errorf("expected size to be %d bytes, got %d bytes",
+			vrf.ProofLength(),
 			len(h),
 		)
 	}


### PR DESCRIPTION
## Description

Since the Header contains the ValidatorHash, Round, and Proof, the Header.ValidateBasic() should perform the stateless validation of the ValidatorsHash, Round and Proof as well.

We also added the below for libsodium support on M1 macs.
```
#cgo darwin,arm64 CFLAGS: -I./sodium/darwin_arm64/include/
#cgo darwin,arm64 LDFLAGS: -L./sodium/darwin_arm64/lib -lsodium
```

## PR Check List
- [ ] This implementation does not return an error if Proof is nil. Should we treat this as an error?
- [ ] I changed the build tag of e2e test from libsodium to r2ishiguro.Is there any problem?

