### PR TITLE
Update the default value of DefaultMaxTolerableByzantinePercentage

### DIFF
--- a/types/params.go
+++ b/types/params.go
@@ -20,8 +20,8 @@ const (
 	// MaxBlockPartsCount is the maximum number of block parts.
 	MaxBlockPartsCount = (MaxBlockSizeBytes / BlockPartSizeBytes) + 1
 
-	DefaultVoterElectionThreshold          = 33
-	DefaultMaxTolerableByzantinePercentage = 20
+	DefaultVoterElectionThreshold          = 33 // 33 is a statistically tested threshold
+	DefaultMaxTolerableByzantinePercentage = 33 // 20 is a statistically tested percentage, but we recommend using 33
 )
 
 // DefaultConsensusParams returns a default ConsensusParams.

--- a/types/voter_set.go
+++ b/types/voter_set.go
@@ -491,7 +491,7 @@ func (voters *VoterSet) StringIndented(indent string) string {
 
 func SelectVoter(validators *ValidatorSet, proofHash []byte, voterParams *VoterParams) *VoterSet {
 	if len(proofHash) == 0 || validators.Size() <= int(voterParams.VoterElectionThreshold) ||
-		voterParams.MaxTolerableByzantinePercentage > BftMaxTolerableByzantinePercentage {
+		voterParams.MaxTolerableByzantinePercentage >= BftMaxTolerableByzantinePercentage {
 		return ToVoterAll(validators.Validators)
 	}
 	seed := hashToSeed(proofHash)
@@ -595,9 +595,9 @@ type voter struct {
 }
 
 func electVotersNonDup(validators []*Validator, seed uint64, tolerableByzantinePercent, minVoters int) []*Validator {
-	// validators is read-only
-	if tolerableByzantinePercent > BftMaxTolerableByzantinePercentage {
-		panic(fmt.Sprintf("tolerableByzantinePercent cannot exceed 33: %d", tolerableByzantinePercent))
+	if tolerableByzantinePercent >= BftMaxTolerableByzantinePercentage {
+		panic(fmt.Sprintf("tolerableByzantinePercent cannot be %d or more: %d",
+			BftMaxTolerableByzantinePercentage, tolerableByzantinePercent))
 	}
 
 	candidates := validatorListCopy(validators)

--- a/types/voter_set_test.go
+++ b/types/voter_set_test.go
@@ -620,7 +620,7 @@ func TestElectVotersNonDupMinVoters(t *testing.T) {
 	rand.Seed(seed)
 	t.Logf("used seed=%d", seed)
 	validatorSet := newValidatorSet(100, func(i int) int64 { return int64(rand.Uint32()%10000 + 100) })
-	tolerableByzantinePercentage := int(rand.Uint() % 33)
+	tolerableByzantinePercentage := int(rand.Uint() % BftMaxTolerableByzantinePercentage)
 	for i := 0; i <= 100; i++ {
 		voters := electVotersNonDup(validatorSet.Validators, rand.Uint64(), tolerableByzantinePercentage, i)
 		assert.True(t, len(voters) >= i, "%d < %d", len(voters), i)
@@ -654,7 +654,7 @@ func TestElectVotersNonDupVoterCountHardCode(t *testing.T) {
 			100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100},
 	}
 	for i := 0; i <= 100; i += 10 {
-		for j := 1; j <= 33; j++ {
+		for j := 1; j < BftMaxTolerableByzantinePercentage; j++ {
 			voters := electVotersNonDup(validatorSet.Validators, 0, j, i)
 			assert.True(t, len(voters) == expected[i/10][j-1])
 		}
@@ -663,7 +663,7 @@ func TestElectVotersNonDupVoterCountHardCode(t *testing.T) {
 	validatorSet = newValidatorSet(100, func(i int) int64 { return int64(100) })
 	expected2 := []int{4, 7, 10, 13, 16, 20, 23, 27, 30, 34, 37, 41, 45, 49, 53, 57, 61, 66, 70, 74, 78, 82, 86, 90,
 		93, 96, 99, 100, 100, 100, 100, 100, 100}
-	for j := 1; j <= 33; j++ {
+	for j := 1; j < BftMaxTolerableByzantinePercentage; j++ {
 		voters := electVotersNonDup(validatorSet.Validators, 0, j, 0)
 		assert.True(t, len(voters) == expected2[j-1])
 	}
@@ -671,7 +671,7 @@ func TestElectVotersNonDupVoterCountHardCode(t *testing.T) {
 	validatorSet = newValidatorSet(100, func(i int) int64 { return int64((i + 1) * (i + 1)) })
 	expected3 := []int{6, 9, 15, 17, 20, 25, 27, 30, 34, 34, 39, 41, 44, 44, 51, 53, 56, 56, 62, 65, 65, 68, 69, 73,
 		100, 100, 100, 100, 100, 100, 100, 100, 100}
-	for j := 1; j <= 33; j++ {
+	for j := 1; j < BftMaxTolerableByzantinePercentage; j++ {
 		voters := electVotersNonDup(validatorSet.Validators, 0, j, 0)
 		assert.True(t, len(voters) == expected3[j-1])
 	}
@@ -686,7 +686,7 @@ func TestElectVotersNonDupVoterCountHardCode(t *testing.T) {
 	validatorSet = newValidatorSet(100, func(i int) int64 { return votingPowerFunc[i] })
 	expected4 := []int{9, 13, 17, 21, 26, 29, 34, 37, 40, 44, 46, 51, 55, 58, 61, 64, 70, 72, 76, 82, 87,
 		100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100}
-	for j := 1; j <= 33; j++ {
+	for j := 1; j < BftMaxTolerableByzantinePercentage; j++ {
 		voters := electVotersNonDup(validatorSet.Validators, 0, j, 0)
 		assert.True(t, len(voters) == expected4[j-1])
 	}
@@ -705,7 +705,7 @@ func TestElectVotersNonDupVoterCountHardCode(t *testing.T) {
 	validatorSet = newValidatorSet(len(votingPowerFuncCosmos), func(i int) int64 { return votingPowerFuncCosmos[i] })
 	expected5 := []int{9, 14, 19, 23, 26, 31, 34, 38, 41, 43, 45, 48, 54, 55, 60, 61, 66, 73, 78, 78, 82, 90,
 		125, 125, 125, 125, 125, 125, 125, 125, 125, 125, 125}
-	for j := 1; j <= 33; j++ {
+	for j := 1; j < BftMaxTolerableByzantinePercentage; j++ {
 		voters := electVotersNonDup(validatorSet.Validators, 0, j, 0)
 		assert.True(t, len(voters) == expected5[j-1])
 	}
@@ -722,7 +722,7 @@ func TestElectVotersNonDupCandidate(t *testing.T) {
 func TestElectVotersNonDupSamplingThreshold(t *testing.T) {
 	candidates := newValidatorSet(100, func(i int) int64 { return int64(1000 * (i + 1)) })
 
-	for i := 1; i <= 33; i++ {
+	for i := 1; i < BftMaxTolerableByzantinePercentage; i++ {
 		winners := electVotersNonDup(candidates.Validators, 0, i, 0)
 		if len(winners) < 100 {
 			assert.True(t, isByzantineTolerable(winners, i))
@@ -918,7 +918,7 @@ func BenchmarkElectVotersNonDupEquity(b *testing.B) {
 	candidates = newValidatorSet(100, func(i int) int64 { return 1000000 + rand.Int64()&0xFFFFF })
 	accumulatedRewards = make(map[string]int64, 100)
 	for i := 0; i < loopCount; i++ {
-		winners := electVotersNonDup(candidates.Validators, uint64(i), 33, 0)
+		winners := electVotersNonDup(candidates.Validators, uint64(i), BftMaxTolerableByzantinePercentage-1, 0)
 		accumulateAndResetReward(winners, accumulatedRewards)
 	}
 	maxRewardPerVotingPowerDiff = float64(0)

--- a/types/voter_set_test.go
+++ b/types/voter_set_test.go
@@ -1150,6 +1150,24 @@ func BenchmarkElectVotersNonDupDistribution(b *testing.B) {
 	}
 }
 
+func TestElectVoterNonDupPanic(t *testing.T) {
+	validatorSet := newValidatorSet(1, func(i int) int64 { return 1 })
+
+	tolerableByzantinePercent := BftMaxTolerableByzantinePercentage + 1
+	expectedResult := fmt.Sprintf("tolerableByzantinePercent cannot be %d or more: %d",
+		BftMaxTolerableByzantinePercentage, tolerableByzantinePercent)
+	defer func() {
+		pnc := recover()
+		if pncStr, ok := pnc.(string); ok {
+			assert.True(t, strings.HasPrefix(pncStr, expectedResult))
+		} else {
+			t.Fatal("panic expected, but doesn't panic")
+		}
+	}()
+	// expected panic
+	electVotersNonDup(validatorSet.Validators, 0, tolerableByzantinePercent, 0)
+}
+
 func TestElectVoterPanic(t *testing.T) {
 
 	validators := newValidatorSet(10, func(i int) int64 { return int64(i + 1) })


### PR DESCRIPTION
## Description

`DefaultMaxTolerableByzantinePercentage` is only guaranteed to prevent byzantine behavior in the selected Voters in hypotheses.

For example, the hypothesis that the network has 10% byzantine behavior with VotingPower=33% or less, only guarantees that VotingWeight will be 33% or less in Voters' behavior with VotingPower=10%.
However, since a hypothesis is just a hypothesis, it is possible for Voters with a total VotingPower of 33% or less to obtain a VotingWeight of 34% or more with `electVotersNonDup`.
So setting the `DefaultMaxTolerableByzantinePercentage` to 33 ensures that VotingPower=33% and VotingWeight is less than 33%.

In addition, if DefaultMaxTolerableByzantinePercentage=33%, it's the same as using `ToVoterAll`.  I also modified it using `ToVoterAll`.
