### PR TITLE
Update using `GITHUB_OUTPUT` environment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION%.*}"
           fi
-          echo ::set-output name=tags::${TAGS}
+          echo "{tags}={${TAGS}}" >> $GITHUB_OUTPUT
 
 #      - name: Set up QEMU
 #        uses: docker/setup-qemu-action@master

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,7 +46,7 @@ jobs:
           VARIANT=$(TZ=UTC-9 date '+%Y%m')${HASH_GHE:0:7}
           NAME_TAR="${VARIANT}.tar"
           CACHE_FILE=${{ env.CACHE_DIR }}"/${NAME_TAR}"
-          echo "::set-output name=CACHE_FILE::${CACHE_FILE}"
+          echo "{CACHE_FILE}={${CACHE_FILE}}" >> $GITHUB_OUTPUT
         if: "env.GIT_DIFF != ''"
 
       - name: Get Docker Image File from cache

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Set crashers count
         working-directory: test/fuzz
-        run: echo "{count}={$(find . -type d -name 'crashers' | xargs -I % sh -c 'ls % | wc -l' | awk '{total += $1} END {print total}')}"
+        run: echo "{count}={$(find . -type d -name 'crashers' | xargs -I % sh -c 'ls % | wc -l' | awk '{total += $1} END {print total}')}" >> $GITHUB_OUTPUT
         id: set-crashers-count
 
     outputs:

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Set crashers count
         working-directory: test/fuzz
-        run: echo "::set-output name=count::$(find . -type d -name 'crashers' | xargs -I % sh -c 'ls % | wc -l' | awk '{total += $1} END {print total}')"
+        run: echo "{count}={$(find . -type d -name 'crashers' | xargs -I % sh -c 'ls % | wc -l' | awk '{total += $1} END {print total}')}"
         id: set-crashers-count
 
     outputs:

--- a/.github/workflows/proto-docker.yml
+++ b/.github/workflows/proto-docker.yml
@@ -38,7 +38,7 @@ jobs:
           if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
             TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION%.*}"
           fi
-          echo ::set-output name=tags::${TAGS}
+          echo "{tags}={${TAGS}}" >> $GITHUB_OUTPUT
 
 #      - name: Set up Docker Buildx
 #        uses: docker/setup-buildx-action@v1.3.0


### PR DESCRIPTION
## Description

Update `set-output` to `GITHUB_OUTPUT`

https://github.com/line/ostracon/actions/runs/3563413762

> Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

