### PR TITLE
fix: add block validation on Fast Sync

### DIFF
--- a/blockchain/v0/reactor.go
+++ b/blockchain/v0/reactor.go
@@ -373,8 +373,14 @@ FOR_LOOP:
 			// NOTE: we can probably make this more efficient, but note that calling
 			// first.Hash() doesn't verify the tx contents, so MakePartSet() is
 			// currently necessary.
-			err := state.Voters.VerifyCommitLight(
-				chainID, firstID, first.Height, second.LastCommit)
+			err := state.Voters.VerifyCommitLight(chainID, firstID, first.Height, second.LastCommit)
+			if err == nil {
+				// validate the block before we persist it
+				err = bcR.blockExec.ValidateBlock(state, first.Round, first)
+			}
+
+			// If either of the checks failed we log the error and request for a new block
+			// at that height
 			if err != nil {
 				bcR.Logger.Error("Error in validation", "err", err)
 				peerID := bcR.pool.RedoRequest(first.Height)


### PR DESCRIPTION
# Description

This PR enable to make block synchronization safer by performing block verification before persisting blocks during Fast Sync. This PR is same as tendermint/tendermint#8493.

## Problem 

> In consensus, we always validate a block before voting and thereby before we persist it, however in blocksync it's possible to persist an invalid block as we only validate it afterwards (in `ApplyBlock`). This potentially puts the node in a bad state where it can't simply rollback the previous execution.

https://github.com/tendermint/tendermint/pull/8493#issue-1231280678

## Fix
I added block validation before before persisting blocks.
