### PR TITLE
fix: fix total voters count

### DIFF
--- a/light/rpc/client.go
+++ b/light/rpc/client.go
@@ -540,7 +540,7 @@ func (c *Client) Voters(ctx context.Context, height *int64, pagePtr, perPagePtr 
 		return nil, err
 	}
 
-	totalCount := len(l.ValidatorSet.Validators)
+	totalCount := len(l.VoterSet.Voters)
 	perPage := validatePerPage(perPagePtr)
 	page, err := validatePage(pagePtr, perPage, totalCount)
 	if err != nil {


### PR DESCRIPTION
## Description

The function `Voters` is used to fetch and verify voters. However, the function `Voters` assigns the length of `l.ValidatorSet.Validators` instead of `l.VoterSet.Voters` to `totalCount`, which may cause incorrect return value in the remaining statements.