### PR TITLE
fix: replace deprecated package `io/ioutil` with `os` or `io`

### DIFF
--- a/abci/example/kvstore/helpers.go
+++ b/abci/example/kvstore/helpers.go
@@ -2,7 +2,7 @@ package kvstore
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/line/ostracon/abci/types"
 	"github.com/line/ostracon/crypto"
@@ -18,7 +18,7 @@ func LoadPrivValidatorKeyFile(keyFilePath string) (*privval.FilePVKey, error) {
 	if !tmos.FileExists(keyFilePath) {
 		return nil, fmt.Errorf("private validator file %s does not exist", keyFilePath)
 	}
-	keyJSONBytes, _ := ioutil.ReadFile(keyFilePath)
+	keyJSONBytes, _ := os.ReadFile(keyFilePath)
 	pvKey := privval.FilePVKey{}
 	err := tmjson.Unmarshal(keyJSONBytes, &pvKey)
 	if err != nil {

--- a/cmd/ostracon/commands/debug/dump.go
+++ b/cmd/ostracon/commands/debug/dump.go
@@ -3,7 +3,6 @@ package debug
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -82,7 +81,7 @@ func dumpCmdHandler(_ *cobra.Command, args []string) error {
 func dumpDebugData(outDir string, conf *cfg.Config, rpc *rpchttp.HTTP) {
 	start := time.Now().UTC()
 
-	tmpDir, err := ioutil.TempDir(outDir, "ostracon_debug_tmp")
+	tmpDir, err := os.MkdirTemp(outDir, "ostracon_debug_tmp")
 	if err != nil {
 		logger.Error("failed to create temporary directory", "dir", tmpDir, "error", err)
 		return

--- a/cmd/ostracon/commands/debug/io.go
+++ b/cmd/ostracon/commands/debug/io.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -111,5 +110,5 @@ func writeStateJSONToFile(state interface{}, dir, filename string) error {
 		return fmt.Errorf("failed to encode state dump: %w", err)
 	}
 
-	return ioutil.WriteFile(path.Join(dir, filename), stateJSON, os.ModePerm)
+	return os.WriteFile(path.Join(dir, filename), stateJSON, os.ModePerm)
 }

--- a/cmd/ostracon/commands/debug/kill.go
+++ b/cmd/ostracon/commands/debug/kill.go
@@ -3,7 +3,6 @@ package debug
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -56,7 +55,7 @@ func killCmdHandler(cmd *cobra.Command, args []string) error {
 
 	// Create a temporary directory which will contain all the state dumps and
 	// relevant files and directories that will be compressed into a file.
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "ostracon_debug_tmp")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "ostracon_debug_tmp")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary directory: %w", err)
 	}

--- a/cmd/ostracon/commands/debug/util.go
+++ b/cmd/ostracon/commands/debug/util.go
@@ -3,7 +3,7 @@ package debug
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -74,10 +74,10 @@ func dumpProfile(dir, addr, profile string, debug int) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read %s profile response body: %w", profile, err)
 	}
 
-	return ioutil.WriteFile(path.Join(dir, fmt.Sprintf("%s.out", profile)), body, os.ModePerm)
+	return os.WriteFile(path.Join(dir, fmt.Sprintf("%s.out", profile)), body, os.ModePerm)
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -3,7 +3,7 @@ package config
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -543,7 +543,7 @@ func ResetTestRoot(testName string) *Config {
 
 func ResetTestRootWithChainID(testName string, chainID string) *Config {
 	// create a unique, concurrency-safe test directory under os.TempDir()
-	rootDir, err := ioutil.TempDir("", fmt.Sprintf("%s-%s_", chainID, testName))
+	rootDir, err := os.MkdirTemp("", fmt.Sprintf("%s-%s_", chainID, testName))
 	if err != nil {
 		panic(err)
 	}

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -3,7 +3,7 @@ package consensus
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime/debug"
 	"sort"
@@ -1997,7 +1997,7 @@ func (cs *State) addProposalBlockPart(msg *BlockPartMessage, peerID p2p.ID) (add
 		)
 	}
 	if added && cs.ProposalBlockParts.IsComplete() {
-		bz, err := ioutil.ReadAll(cs.ProposalBlockParts.GetReader())
+		bz, err := io.ReadAll(cs.ProposalBlockParts.GetReader())
 		if err != nil {
 			return added, err
 		}

--- a/crypto/armor/armor.go
+++ b/crypto/armor/armor.go
@@ -3,7 +3,7 @@ package armor
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"golang.org/x/crypto/openpgp/armor" //nolint: staticcheck // nobody uses this package but leave for a moment
 )
@@ -31,7 +31,7 @@ func DecodeArmor(armorStr string) (blockType string, headers map[string]string, 
 	if err != nil {
 		return "", nil, nil, err
 	}
-	data, err = ioutil.ReadAll(block.Body)
+	data, err = io.ReadAll(block.Body)
 	if err != nil {
 		return "", nil, nil, err
 	}

--- a/libs/cli/helper.go
+++ b/libs/cli/helper.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -19,7 +18,7 @@ func WriteConfigVals(dir string, vals map[string]string) error {
 		data += fmt.Sprintf("%s = \"%s\"\n", k, v)
 	}
 	cfile := filepath.Join(dir, "config.toml")
-	return ioutil.WriteFile(cfile, []byte(data), 0600)
+	return os.WriteFile(cfile, []byte(data), 0600)
 }
 
 // RunWithArgs executes the given command with the specified command line args

--- a/libs/os/os.go
+++ b/libs/os/os.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -60,11 +59,11 @@ func FileExists(filePath string) bool {
 }
 
 func ReadFile(filePath string) ([]byte, error) {
-	return ioutil.ReadFile(filePath)
+	return os.ReadFile(filePath)
 }
 
 func MustReadFile(filePath string) []byte {
-	fileBytes, err := ioutil.ReadFile(filePath)
+	fileBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		Exit(fmt.Sprintf("MustReadFile failed: %v", err))
 		return nil
@@ -73,7 +72,7 @@ func MustReadFile(filePath string) []byte {
 }
 
 func WriteFile(filePath string, contents []byte, mode os.FileMode) error {
-	return ioutil.WriteFile(filePath, contents, mode)
+	return os.WriteFile(filePath, contents, mode)
 }
 
 func MustWriteFile(filePath string, contents []byte, mode os.FileMode) {

--- a/p2p/key.go
+++ b/p2p/key.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/line/ostracon/crypto"
 	"github.com/line/ostracon/crypto/ed25519"
@@ -70,7 +70,7 @@ func LoadOrGenNodeKey(filePath string) (*NodeKey, error) {
 
 // LoadNodeKey loads NodeKey located in filePath.
 func LoadNodeKey(filePath string) (*NodeKey, error) {
-	jsonBytes, err := ioutil.ReadFile(filePath)
+	jsonBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (nodeKey *NodeKey) SaveAs(filePath string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filePath, jsonBytes, 0600)
+	err = os.WriteFile(filePath, jsonBytes, 0600)
 	if err != nil {
 		return err
 	}

--- a/p2p/upnp/upnp.go
+++ b/p2p/upnp/upnp.go
@@ -10,7 +10,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -316,7 +316,7 @@ func (n *upnpNAT) getExternalIPAddress() (info statusInfo, err error) {
 		return
 	}
 	var envelope Envelope
-	data, err := ioutil.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
 	if err != nil {
 		return
 	}

--- a/privval/file.go
+++ b/privval/file.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -206,7 +206,7 @@ func LoadFilePVEmptyState(keyFilePath, stateFilePath string) *FilePV {
 
 // If loadState is true, we load from the stateFilePath. Otherwise, we use an empty LastSignState.
 func loadFilePV(keyFilePath, stateFilePath string, loadState bool) *FilePV {
-	keyJSONBytes, err := ioutil.ReadFile(keyFilePath)
+	keyJSONBytes, err := os.ReadFile(keyFilePath)
 	if err != nil {
 		tmos.Exit(err.Error())
 	}
@@ -224,7 +224,7 @@ func loadFilePV(keyFilePath, stateFilePath string, loadState bool) *FilePV {
 	pvState := FilePVLastSignState{}
 
 	if loadState {
-		stateJSONBytes, err := ioutil.ReadFile(stateFilePath)
+		stateJSONBytes, err := os.ReadFile(stateFilePath)
 		if err != nil {
 			tmos.Exit(err.Error())
 		}

--- a/rpc/jsonrpc/client/http_json_client.go
+++ b/rpc/jsonrpc/client/http_json_client.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -222,7 +222,7 @@ func (c *Client) Call(
 
 	defer httpResponse.Body.Close()
 
-	responseBytes, err := ioutil.ReadAll(httpResponse.Body)
+	responseBytes, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response body: %w", err)
 	}
@@ -270,7 +270,7 @@ func (c *Client) sendBatch(ctx context.Context, requests []*jsonRPCBufferedReque
 
 	defer httpResponse.Body.Close()
 
-	responseBytes, err := ioutil.ReadAll(httpResponse.Body)
+	responseBytes, err := io.ReadAll(httpResponse.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read response body: %w", err)
 	}

--- a/rpc/jsonrpc/client/http_uri_client.go
+++ b/rpc/jsonrpc/client/http_uri_client.go
@@ -3,7 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -76,7 +76,7 @@ func (c *URIClient) Call(ctx context.Context, method string,
 	}
 	defer resp.Body.Close()
 
-	responseBytes, err := ioutil.ReadAll(resp.Body)
+	responseBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("read response body: %w", err)
 	}

--- a/rpc/jsonrpc/server/http_json_handler.go
+++ b/rpc/jsonrpc/server/http_json_handler.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"sort"
@@ -19,7 +19,7 @@ import (
 // jsonrpc calls grab the given method's function info and runs reflect.Call
 func makeJSONRPCHandler(funcMap map[string]*RPCFunc, logger log.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		b, err := ioutil.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			res := types.RPCInvalidRequestError(nil,
 				fmt.Errorf("error reading request body: %w", err),

--- a/state/state.go
+++ b/state/state.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/line/ostracon/crypto"
@@ -340,7 +340,7 @@ func MakeGenesisStateFromFile(genDocFile string) (State, error) {
 
 // MakeGenesisDocFromFile reads and unmarshals genesis doc from the given file.
 func MakeGenesisDocFromFile(genDocFile string) (*types.GenesisDoc, error) {
-	genDocJSON, err := ioutil.ReadFile(genDocFile)
+	genDocJSON, err := os.ReadFile(genDocFile)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read GenesisDoc file: %v", err)
 	}

--- a/statesync/chunks.go
+++ b/statesync/chunks.go
@@ -3,7 +3,6 @@ package statesync
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -42,7 +41,7 @@ type chunkQueue struct {
 // newChunkQueue creates a new chunk queue for a snapshot, using a temp dir for storage.
 // Callers must call Close() when done.
 func newChunkQueue(snapshot *snapshot, tempDir string) (*chunkQueue, error) {
-	dir, err := ioutil.TempDir(tempDir, "oc-statesync")
+	dir, err := os.MkdirTemp(tempDir, "oc-statesync")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create temp dir for state sync chunks: %w", err)
 	}
@@ -84,7 +83,7 @@ func (q *chunkQueue) Add(chunk *chunk) (bool, error) {
 	}
 
 	path := filepath.Join(q.dir, strconv.FormatUint(uint64(chunk.Index), 10))
-	err := ioutil.WriteFile(path, chunk.Chunk, 0600)
+	err := os.WriteFile(path, chunk.Chunk, 0600)
 	if err != nil {
 		return false, fmt.Errorf("failed to save chunk %v to file %v: %w", chunk.Index, path, err)
 	}
@@ -209,7 +208,7 @@ func (q *chunkQueue) load(index uint32) (*chunk, error) {
 	if !ok {
 		return nil, nil
 	}
-	body, err := ioutil.ReadFile(path)
+	body, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load chunk %v: %w", index, err)
 	}

--- a/types/genesis.go
+++ b/types/genesis.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"github.com/line/ostracon/crypto"
@@ -154,7 +154,7 @@ func GenesisDocFromJSON(jsonBlob []byte) (*GenesisDoc, error) {
 
 // GenesisDocFromFile reads JSON data from a file and unmarshalls it into a GenesisDoc.
 func GenesisDocFromFile(genDocFile string) (*GenesisDoc, error) {
-	jsonBlob, err := ioutil.ReadFile(genDocFile)
+	jsonBlob, err := os.ReadFile(genDocFile)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read GenesisDoc file: %w", err)
 	}


### PR DESCRIPTION
## Description

Replace deprecated `io/ioutil` package since Go 1.16.

* ioutil.TempDir -> os.MkdirTemp
* ioutil.WriteFile -> os.WriteFile
* ioutil.ReadAll -> io.ReadAll
* ioutil.ReadFile -> os.ReadFile

