### PR TITLE
fix: remove strange `Ping`

### DIFF
--- a/privval/retry_signer_client.go
+++ b/privval/retry_signer_client.go
@@ -40,10 +40,6 @@ func (sc *RetrySignerClient) WaitForConnection(maxWait time.Duration) error {
 //--------------------------------------------------------
 // Implement PrivValidator
 
-func (sc *RetrySignerClient) Ping() error {
-	return sc.next.Ping()
-}
-
 func (sc *RetrySignerClient) GetPubKey() (crypto.PubKey, error) {
 	var (
 		pk  crypto.PubKey

--- a/privval/signer_client.go
+++ b/privval/signer_client.go
@@ -50,22 +50,6 @@ func (sc *SignerClient) WaitForConnection(maxWait time.Duration) error {
 //--------------------------------------------------------
 // Implement PrivValidator
 
-// Ping sends a ping request to the remote signer
-func (sc *SignerClient) Ping() error {
-	response, err := sc.endpoint.SendRequest(mustWrapMsg(&privvalproto.PingRequest{}))
-	if err != nil {
-		sc.endpoint.Logger.Error("SignerClient::Ping", "err", err)
-		return nil
-	}
-
-	pb := response.GetPingResponse()
-	if pb == nil {
-		return err
-	}
-
-	return nil
-}
-
 // GetPubKey retrieves a public key from a remote signer
 // returns an error if client is not able to provide the key
 func (sc *SignerClient) GetPubKey() (crypto.PubKey, error) {

--- a/privval/signer_client_test.go
+++ b/privval/signer_client_test.go
@@ -71,25 +71,6 @@ func TestSignerClose(t *testing.T) {
 	}
 }
 
-func TestSignerPing(t *testing.T) {
-	for _, tc := range getSignerTestCases(t, nil, true) {
-		tc := tc
-		t.Cleanup(func() {
-			if err := tc.signerServer.Stop(); err != nil {
-				t.Error(err)
-			}
-		})
-		t.Cleanup(func() {
-			if err := tc.signerClient.Close(); err != nil {
-				t.Error(err)
-			}
-		})
-
-		err := tc.signerClient.Ping()
-		assert.NoError(t, err)
-	}
-}
-
 func TestSignerGetPubKey(t *testing.T) {
 	for _, tc := range getSignerTestCases(t, nil, true) {
 		tc := tc

--- a/test/kms/bench_test.go
+++ b/test/kms/bench_test.go
@@ -42,17 +42,6 @@ func BenchmarkKMS(b *testing.B) {
 	client, err := privval.NewSignerClient(endpoint, chainID)
 	require.NoError(b, err)
 
-	// ensure connection and warm up
-	b.Run("Ping", func(b *testing.B) {
-		var err error
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			err = client.Ping()
-		}
-		b.StopTimer()
-		require.NoError(b, err)
-	})
-
 	benchmarkPrivValidator(b, client)
 }
 


### PR DESCRIPTION
## Description

`Ping` function is used in only test.  But it always returns nil which is meaningless. So I removed it. Removing has no problem for spec.

https://github.com/informalsystems/tendermint-rs/blob/main/docs/architecture/adr-011-validator-crate.md

**`Ping` History:**

- https://github.com/tendermint/tendermint/pull/2568/files#diff-21b28fcbc3e3f755a54323769b10510e7c144d521e05d065dac8f8360928baa7R79
- https://github.com/tendermint/tendermint/pull/3351/files#diff-4c9597947b77f66a0436065caefa4420fc94bf63faefe22979db4bbfd9720aaeL131
- https://github.com/tendermint/tendermint/pull/3370/files#diff-f26cb79f69b0f0824a4e09e13ce477efdfc05d9ae1101d6cee5eae8ed09539edR51

It seemed to be left behind after repeated refactorings.