### PR TITLE
Align with ValidatorSet on `PruneStates()`

### DIFF
--- a/state/store.go
+++ b/state/store.go
@@ -311,6 +311,14 @@ func (store dbStore) PruneStates(from int64, to int64) error {
 			if err != nil {
 				return err
 			}
+			err = batch.Delete(calcVoterParamsKey(h))
+			if err != nil {
+				return err
+			}
+			err = batch.Delete(calcProofHashKey(h))
+			if err != nil {
+				return err
+			}
 		}
 
 		if keepParams[h] {
@@ -343,16 +351,6 @@ func (store dbStore) PruneStates(from int64, to int64) error {
 			}
 		}
 
-		err = batch.Delete(calcVoterParamsKey(h))
-		if err != nil {
-			return err
-		}
-
-		err = batch.Delete(calcProofHashKey(h))
-		if err != nil {
-			return err
-		}
-
 		err = batch.Delete(calcABCIResponsesKey(h))
 		if err != nil {
 			return err
@@ -367,7 +365,6 @@ func (store dbStore) PruneStates(from int64, to int64) error {
 			}
 			batch.Close()
 			batch = store.db.NewBatch()
-			defer batch.Close()
 		}
 	}
 

--- a/state/store_test.go
+++ b/state/store_test.go
@@ -299,6 +299,15 @@ func TestPruneStates(t *testing.T) {
 					require.Error(t, err, "abci height %v", h)
 					require.Equal(t, sm.ErrNoABCIResponsesForHeight{Height: h}, err)
 				}
+				_, voters, voterParams, proof, err := stateStore.LoadVoters(h, nil)
+				if expectVals[h] {
+					require.NotNil(t, voters)
+					require.NotNil(t, voterParams)
+					require.NotNil(t, proof)
+				} else {
+					require.Error(t, err, "validators height %v", h)
+					require.Equal(t, sm.ErrNoValSetForHeight{Height: h}, err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Description

#502 didn't test `VoterParam` and `ProofHash`, so the response wasn't sufficient. I aligned it with the removing process of `ValidatorSet` for the consistency between `ValidatorSet`, `VoterParam`, and `ProofHash`.


