### PR TITLE
Fix the bug of Ostracon's changes of #194

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -146,7 +146,11 @@ func (blockExec *BlockExecutor) CreateProposalBlock(
 // Validation does not mutate state, but does require historical information from the stateDB,
 // ie. to verify evidence from a validator at an old height.
 func (blockExec *BlockExecutor) ValidateBlock(state State, round int32, block *types.Block) error {
-	return validateBlock(state, round, block)
+	err := validateBlock(state, round, block)
+	if err != nil {
+		return err
+	}
+	return blockExec.evpool.CheckEvidence(block.Evidence.Evidence)
 }
 
 // ApplyBlock validates the block against the state, executes it against the app,

--- a/types/protobuf.go
+++ b/types/protobuf.go
@@ -50,7 +50,7 @@ func (oc2pb) Header(header *Header) tmproto.Header {
 		LastCommitHash: header.LastCommitHash,
 		DataHash:       header.DataHash,
 
-		VotersHash:         header.VotersHash,
+		ValidatorsHash:     header.ValidatorsHash,
 		NextValidatorsHash: header.NextValidatorsHash,
 		ConsensusHash:      header.ConsensusHash,
 		AppHash:            header.AppHash,
@@ -58,6 +58,11 @@ func (oc2pb) Header(header *Header) tmproto.Header {
 
 		EvidenceHash:    header.EvidenceHash,
 		ProposerAddress: header.ProposerAddress,
+
+		// Ostracon fields
+		Round:      header.Round,
+		Proof:      header.Proof,
+		VotersHash: header.VotersHash,
 	}
 }
 

--- a/types/validator.go
+++ b/types/validator.go
@@ -99,10 +99,11 @@ func (v *Validator) String() string {
 	if v == nil {
 		return "nil-Validator"
 	}
-	return fmt.Sprintf("Validator{%v %v VP:%v A:%v}",
+	return fmt.Sprintf("Validator{%v %v VP:%v VW:%v A:%v}",
 		v.Address,
 		v.PubKey,
 		v.VotingPower,
+		v.VotingWeight,
 		v.ProposerPriority)
 }
 


### PR DESCRIPTION
## Description

#194 was made of too many things. But, it made some of the wrong changes. Here are the wrong changes:
* Remove to call `CheckEvidence` on `execution.go:ValidateBlock`
* Forget to add the fields of `Round/Proof` on `protobuf.go:Header`
* Mistake to remove the field of `ValidatorHash` on `protobuf.go:Header`
* Forget to add the field of `VotingWeight` on `validator.go:String`


