### PR TITLE
Fix to change expected of test according to build tag

### DIFF
--- a/crypto/vrf/vrf_coniks.go
+++ b/crypto/vrf/vrf_coniks.go
@@ -19,7 +19,10 @@ func init() {
 	defaultVrf = newVrfEd25519coniks()
 }
 
-const ProofSize = coniks.ProofSize
+const (
+	ProofSize  = coniks.ProofSize
+	OutputSize = coniks.Size
+)
 
 func newVrfEd25519coniks() *vrfEd25519coniks {
 	return &vrfEd25519coniks{nil, nil}

--- a/crypto/vrf/vrf_libsodium.go
+++ b/crypto/vrf/vrf_libsodium.go
@@ -18,7 +18,10 @@ func init() {
 	defaultVrf = newVrfEd25519libsodium()
 }
 
-const ProofSize = int(libsodium.PROOFBYTES)
+const (
+	ProofSize  = int(libsodium.PROOFBYTES)
+	OutputSize = int(libsodium.OUTPUTBYTES)
+)
 
 func newVrfEd25519libsodium() vrfEd25519libsodium {
 	return vrfEd25519libsodium{}

--- a/crypto/vrf/vrf_r2ishiguro.go
+++ b/crypto/vrf/vrf_r2ishiguro.go
@@ -19,7 +19,10 @@ func init() {
 	}
 }
 
-const ProofSize = 81
+const (
+	ProofSize  = 81
+	OutputSize = 32
+)
 
 func newVrfEd25519r2ishiguro() vrfEd25519r2ishiguro {
 	return vrfEd25519r2ishiguro{}

--- a/test/kms/bench_test.go
+++ b/test/kms/bench_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/line/ostracon/config"
 	"github.com/line/ostracon/crypto"
 	"github.com/line/ostracon/crypto/ed25519"
+	"github.com/line/ostracon/crypto/vrf"
 	"github.com/line/ostracon/libs/log"
 	tmnet "github.com/line/ostracon/libs/net"
 	"github.com/line/ostracon/node"
@@ -29,9 +30,6 @@ var logger = log.NewOCLogger(log.NewSyncWriter(os.Stdout))
 
 const chainID = "test-chain"
 const listenAddr = "tcp://0.0.0.0:45666"
-
-const VrfProofSize = 80
-const VrfOutputSize = 64
 
 func BenchmarkKMS(b *testing.B) {
 	chainID := "test-chain"
@@ -177,10 +175,10 @@ func benchmarkVRFProof(b *testing.B, pv types.PrivValidator, pubKey crypto.PubKe
 
 	// evaluate execution results
 	require.NoError(b, err)
-	require.Equalf(b, len(proof), VrfProofSize, "VRFProof: proof size = %d != %d", len(proof), VrfProofSize)
+	require.Equalf(b, vrf.ProofSize, len(proof), "VRFProof: proof size = %d != %d", len(proof), vrf.ProofSize)
 	output, err := pubKey.VRFVerify(proof, message)
 	require.NoError(b, err)
-	require.Equalf(b, len(output), VrfOutputSize, "VRFProof: output size = %d != %d", len(output), VrfOutputSize)
+	require.Equalf(b, vrf.OutputSize, len(output), "VRFProof: output size = %d != %d", len(output), vrf.OutputSize)
 }
 
 func ping(sl *privval.SignerListenerEndpoint) {


### PR DESCRIPTION
## Description

The mismatch between the constant VrfProofSize and the result of the function GenerateVRFProof() as well as the constant VrfOutputSize and the result of the function VRFVerify() will lead to the failure of the benchmark test, benchmarkVRFProof().

I fixed the constants VrfProofSize and VrfOutputSize to change according to the build tag and to invert the expected and actual values ​​passed in the function require.Equalf().