### PR TITLE
Fix MaxHeaderSize

### DIFF
--- a/crypto/vrf/vrf_coniks.go
+++ b/crypto/vrf/vrf_coniks.go
@@ -20,8 +20,8 @@ func init() {
 }
 
 const (
-	ProofSize  = coniks.ProofSize
-	OutputSize = coniks.Size
+	ProofSize  int = coniks.ProofSize
+	OutputSize int = coniks.Size
 )
 
 func newVrfEd25519coniks() *vrfEd25519coniks {

--- a/crypto/vrf/vrf_libsodium.go
+++ b/crypto/vrf/vrf_libsodium.go
@@ -19,8 +19,8 @@ func init() {
 }
 
 const (
-	ProofSize  = int(libsodium.PROOFBYTES)
-	OutputSize = int(libsodium.OUTPUTBYTES)
+	ProofSize  int = int(libsodium.PROOFBYTES)
+	OutputSize int = int(libsodium.OUTPUTBYTES)
 )
 
 func newVrfEd25519libsodium() vrfEd25519libsodium {

--- a/crypto/vrf/vrf_r2ishiguro.go
+++ b/crypto/vrf/vrf_r2ishiguro.go
@@ -20,8 +20,8 @@ func init() {
 }
 
 const (
-	ProofSize  = 81
-	OutputSize = 32
+	ProofSize  int = 81
+	OutputSize int = 32
 )
 
 func newVrfEd25519r2ishiguro() vrfEd25519r2ishiguro {

--- a/proto/ostracon/types/types.proto
+++ b/proto/ostracon/types/types.proto
@@ -82,6 +82,7 @@ message Header {
   bytes proposer_address = 14;  // original proposer of the block
 
   // *** Ostracon Extended Fields ***
+  // Note that MaxHeaderSize must be modified when adding/removing fields.
 
   // vrf info
   int32 round       = 1000;

--- a/state/tx_filter_test.go
+++ b/state/tx_filter_test.go
@@ -9,6 +9,7 @@ import (
 
 	dbm "github.com/tendermint/tm-db"
 
+	"github.com/line/ostracon/crypto/vrf"
 	tmrand "github.com/line/ostracon/libs/rand"
 	sm "github.com/line/ostracon/state"
 	"github.com/line/ostracon/types"
@@ -25,8 +26,8 @@ func TestTxFilter(t *testing.T) {
 		tx    types.Tx
 		isErr bool
 	}{
-		{types.Tx(tmrand.Bytes(2122)), false},
-		{types.Tx(tmrand.Bytes(2123)), true},
+		{types.Tx(tmrand.Bytes(2112 - vrf.ProofSize)), false},
+		{types.Tx(tmrand.Bytes(2113 - vrf.ProofSize)), true},
 		{types.Tx(tmrand.Bytes(3000)), true},
 	}
 

--- a/types/block.go
+++ b/types/block.go
@@ -17,6 +17,7 @@ import (
 	"github.com/line/ostracon/crypto/composite"
 	"github.com/line/ostracon/crypto/merkle"
 	"github.com/line/ostracon/crypto/tmhash"
+	"github.com/line/ostracon/crypto/vrf"
 	"github.com/line/ostracon/libs/bits"
 	tmbytes "github.com/line/ostracon/libs/bytes"
 	tmmath "github.com/line/ostracon/libs/math"
@@ -30,7 +31,12 @@ const (
 	// MaxHeaderBytes is a maximum header size.
 	// NOTE: Because app hash can be of arbitrary size, the header is therefore not
 	// capped in size and thus this number should be seen as a soft max
-	MaxHeaderBytes int64 = 661
+	// 🏺 Note that this value is the encoded size of the ProtocolBuffer. See TestMaxHeaderBytes() for how Tendermint
+	//  calculates this value. Add/remove Ostracon-specific field sizes to/from this heuristically determined constant.
+	MaxHeaderBytes int64 = 626 +
+		(2 + 32 + 1) + // +VotersHash
+		(2 + 5) + // +Round
+		(2 + int64(vrf.ProofSize) + 1) // +Proof
 
 	// MaxOverheadForBlock - maximum overhead to encode a block (up to
 	// MaxBlockSizeBytes in size) not including it's parts except Data.

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -745,6 +745,11 @@ func TestMaxHeaderBytes(t *testing.T) {
 	// year int, month Month, day, hour, min, sec, nsec int, loc *Location
 	timestamp := time.Date(math.MaxInt64, 0, 0, 0, 0, 0, math.MaxInt64, time.UTC)
 
+	proof := make([]byte, vrf.ProofSize)
+	for i := 0; i < len(proof); i++ {
+		proof[i] = 0xFF
+	}
+
 	h := Header{
 		Version:            tmversion.Consensus{Block: math.MaxInt64, App: math.MaxInt64},
 		ChainID:            maxChainID,
@@ -761,6 +766,8 @@ func TestMaxHeaderBytes(t *testing.T) {
 		LastResultsHash:    tmhash.Sum([]byte("last_results_hash")),
 		EvidenceHash:       tmhash.Sum([]byte("evidence_hash")),
 		ProposerAddress:    crypto.AddressHash([]byte("proposer_address")),
+		Round:              math.MaxInt32,
+		Proof:              proof,
 	}
 
 	bz, err := h.ToProto().Marshal()
@@ -995,9 +1002,9 @@ func TestBlockMaxDataBytes(t *testing.T) {
 	}{
 		0: {-10, commit, []Evidence{dupEv}, true, 0},
 		1: {10, commit, []Evidence{dupEv}, true, 0},
-		2: {1600, commit, []Evidence{dupEv}, true, 0},
-		3: {1692, commit, []Evidence{dupEv}, false, 0},
-		4: {1693, commit, []Evidence{dupEv}, false, 1},
+		2: {1701 + int64(vrf.ProofSize), commit, []Evidence{dupEv}, true, 0},
+		3: {1702 + int64(vrf.ProofSize), commit, []Evidence{dupEv}, false, 0},
+		4: {1703 + int64(vrf.ProofSize), commit, []Evidence{dupEv}, false, 1},
 	}
 
 	for i, tc := range testCases {
@@ -1027,9 +1034,9 @@ func TestBlockMaxDataBytesNoEvidence(t *testing.T) {
 	}{
 		0: {-10, 1, true, 0},
 		1: {10, 1, true, 0},
-		2: {909, 1, true, 0},
-		3: {910, 1, false, 0},
-		4: {911, 1, false, 1},
+		2: {919 + int64(vrf.ProofSize), 1, true, 0},
+		3: {920 + int64(vrf.ProofSize), 1, false, 0},
+		4: {921 + int64(vrf.ProofSize), 1, false, 1},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
## Description

`MaxHeaderSize` represents the maximum size of the `Header` encoded in ProtocolBuffers (`ChannelID` seems to be the arbitrary length, so it's treated as 'softmax'); Protobuf encodes integers with variable length, so the size isn't fixed, but the maximum value of the `Proof` and `Round` fields added in Ostracon were not calculated to this maximum value.

This PR re-adjust the `MaxHeaderSize` to be the maximum size that `Proof` and `Round` can take. In addition, for clarity, I leave the Tendermint constant of 626 to add/remove the size of the field we have changed for the `Header`.

Closes: #XXX

