### PR TITLE
Fix the mismatch between "State.Version.Consensus.App" and "State.ConsensusParams.Version.AppVersion"

### DIFF
--- a/abci/example/kvstore/kvstore.go
+++ b/abci/example/kvstore/kvstore.go
@@ -17,7 +17,7 @@ var (
 	stateKey        = []byte("stateKey")
 	kvPairPrefixKey = []byte("kvPairKey:")
 
-	ProtocolVersion uint64 = 0x1
+	ProtocolVersion uint64 = 99
 )
 
 type State struct {

--- a/blockchain/msgs_test.go
+++ b/blockchain/msgs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	bcproto "github.com/line/ostracon/proto/ostracon/blockchain"
+	sm "github.com/line/ostracon/state"
 	"github.com/line/ostracon/types"
 )
 
@@ -80,7 +81,7 @@ func TestBcStatusResponseMessageValidateBasic(t *testing.T) {
 
 // nolint:lll // ignore line length in tests
 func TestBlockchainMessageVectors(t *testing.T) {
-	block := types.MakeBlock(int64(3), []types.Tx{types.Tx("Hello World")}, nil, nil)
+	block := types.MakeBlock(int64(3), []types.Tx{types.Tx("Hello World")}, nil, nil, sm.InitStateVersion.Consensus)
 	block.Version.Block = 11 // overwrite updated protocol version
 	block.Version.App = 11   // overwrite updated protocol version
 

--- a/blockchain/msgs_test.go
+++ b/blockchain/msgs_test.go
@@ -82,6 +82,7 @@ func TestBcStatusResponseMessageValidateBasic(t *testing.T) {
 func TestBlockchainMessageVectors(t *testing.T) {
 	block := types.MakeBlock(int64(3), []types.Tx{types.Tx("Hello World")}, nil, nil)
 	block.Version.Block = 11 // overwrite updated protocol version
+	block.Version.App = 11   // overwrite updated protocol version
 
 	bpb, err := block.ToProto()
 	require.NoError(t, err)
@@ -97,7 +98,7 @@ func TestBlockchainMessageVectors(t *testing.T) {
 			BlockRequest: &bcproto.BlockRequest{Height: math.MaxInt64}}},
 			"0a0a08ffffffffffffffff7f"},
 		{"BlockResponseMessage", &bcproto.Message{Sum: &bcproto.Message_BlockResponse{
-			BlockResponse: &bcproto.BlockResponse{Block: bpb}}}, "1a700a6e0a5b0a02080b1803220b088092b8c398feffffff012a0212003a20c4da88e876062aa1543400d50d0eaa0dac88096057949cfb7bca7f3a48c04bf96a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855120d0a0b48656c6c6f20576f726c641a00"},
+			BlockResponse: &bcproto.BlockResponse{Block: bpb}}}, "1a720a700a5d0a04080b100b1803220b088092b8c398feffffff012a0212003a20c4da88e876062aa1543400d50d0eaa0dac88096057949cfb7bca7f3a48c04bf96a20e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855120d0a0b48656c6c6f20576f726c641a00"},
 		{"NoBlockResponseMessage", &bcproto.Message{Sum: &bcproto.Message_NoBlockResponse{
 			NoBlockResponse: &bcproto.NoBlockResponse{Height: 1}}}, "12020801"},
 		{"NoBlockResponseMessage", &bcproto.Message{Sum: &bcproto.Message_NoBlockResponse{

--- a/blockchain/v1/peer_test.go
+++ b/blockchain/v1/peer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/line/ostracon/libs/log"
 	tmrand "github.com/line/ostracon/libs/rand"
 	"github.com/line/ostracon/p2p"
+	sm "github.com/line/ostracon/state"
 	"github.com/line/ostracon/types"
 )
 
@@ -276,5 +277,5 @@ func checkByStoppingPeerTimer(t *testing.T, peer *BpPeer, running bool) {
 }
 
 func makeSmallBlock(height int) *types.Block {
-	return types.MakeBlock(int64(height), []types.Tx{types.Tx("foo")}, nil, nil)
+	return types.MakeBlock(int64(height), []types.Tx{types.Tx("foo")}, nil, nil, sm.InitStateVersion.Consensus)
 }

--- a/blockchain/v1/pool_test.go
+++ b/blockchain/v1/pool_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/line/ostracon/libs/log"
 	"github.com/line/ostracon/p2p"
+	sm "github.com/line/ostracon/state"
 	"github.com/line/ostracon/types"
 )
 
@@ -81,7 +82,9 @@ func makeBlockPool(bcr *testBcR, height int64, peers []BpPeer, blocks map[int64]
 		bPool.peers[p.id].RequestSent(h)
 		if p.create {
 			// simulate that a block at height h has been received
-			_ = bPool.peers[p.id].AddBlock(types.MakeBlock(h, txs, nil, nil), 100)
+			_ = bPool.peers[p.id].AddBlock(
+				types.MakeBlock(h, txs, nil, nil, sm.InitStateVersion.Consensus),
+				100)
 		}
 	}
 	return bPool
@@ -392,7 +395,7 @@ func TestBlockPoolAddBlock(t *testing.T) {
 			pool: makeBlockPool(testBcR, 10, []BpPeer{{ID: "P1", Height: 100}}, map[int64]tPBlocks{}),
 			args: args{
 				peerID:    "P2",
-				block:     types.MakeBlock(int64(10), txs, nil, nil),
+				block:     types.MakeBlock(int64(10), txs, nil, nil, sm.InitStateVersion.Consensus),
 				blockSize: 100,
 			},
 			poolWanted: makeBlockPool(testBcR, 10, []BpPeer{{ID: "P1", Height: 100}}, map[int64]tPBlocks{}),
@@ -404,7 +407,7 @@ func TestBlockPoolAddBlock(t *testing.T) {
 				map[int64]tPBlocks{10: {"P1", false}}),
 			args: args{
 				peerID:    "P1",
-				block:     types.MakeBlock(int64(11), txs, nil, nil),
+				block:     types.MakeBlock(int64(11), txs, nil, nil, sm.InitStateVersion.Consensus),
 				blockSize: 100,
 			},
 			poolWanted: makeBlockPool(testBcR, 10,
@@ -418,7 +421,7 @@ func TestBlockPoolAddBlock(t *testing.T) {
 				map[int64]tPBlocks{10: {"P1", true}, 11: {"P1", false}}),
 			args: args{
 				peerID:    "P1",
-				block:     types.MakeBlock(int64(10), txs, nil, nil),
+				block:     types.MakeBlock(int64(10), txs, nil, nil, sm.InitStateVersion.Consensus),
 				blockSize: 100,
 			},
 			poolWanted: makeBlockPool(testBcR, 10,
@@ -432,7 +435,7 @@ func TestBlockPoolAddBlock(t *testing.T) {
 				map[int64]tPBlocks{10: {"P1", false}}),
 			args: args{
 				peerID:    "P2",
-				block:     types.MakeBlock(int64(10), txs, nil, nil),
+				block:     types.MakeBlock(int64(10), txs, nil, nil, sm.InitStateVersion.Consensus),
 				blockSize: 100,
 			},
 			poolWanted: makeBlockPool(testBcR, 10,
@@ -446,7 +449,7 @@ func TestBlockPoolAddBlock(t *testing.T) {
 				map[int64]tPBlocks{10: {"P1", false}}),
 			args: args{
 				peerID:    "P1",
-				block:     types.MakeBlock(int64(10), txs, nil, nil),
+				block:     types.MakeBlock(int64(10), txs, nil, nil, sm.InitStateVersion.Consensus),
 				blockSize: 100,
 			},
 			poolWanted: makeBlockPool(testBcR, 10,

--- a/blockchain/v1/reactor_fsm_test.go
+++ b/blockchain/v1/reactor_fsm_test.go
@@ -11,6 +11,7 @@ import (
 	tmmath "github.com/line/ostracon/libs/math"
 	tmrand "github.com/line/ostracon/libs/rand"
 	"github.com/line/ostracon/p2p"
+	sm "github.com/line/ostracon/state"
 	"github.com/line/ostracon/types"
 )
 
@@ -142,7 +143,7 @@ func sBlockRespEv(current, expected string, peerID p2p.ID, height int64, prevBlo
 		data: bReactorEventData{
 			peerID: peerID,
 			height: height,
-			block:  types.MakeBlock(height, txs, nil, nil),
+			block:  types.MakeBlock(height, txs, nil, nil, sm.InitStateVersion.Consensus),
 			length: 100},
 		wantState:     expected,
 		wantNewBlocks: append(prevBlocks, height),
@@ -159,7 +160,7 @@ func sBlockRespEvErrored(current, expected string,
 		data: bReactorEventData{
 			peerID: peerID,
 			height: height,
-			block:  types.MakeBlock(height, txs, nil, nil),
+			block:  types.MakeBlock(height, txs, nil, nil, sm.InitStateVersion.Consensus),
 			length: 100},
 		wantState:        expected,
 		wantErr:          wantErr,

--- a/consensus/wal_generator.go
+++ b/consensus/wal_generator.go
@@ -20,7 +20,6 @@ import (
 	sm "github.com/line/ostracon/state"
 	"github.com/line/ostracon/store"
 	"github.com/line/ostracon/types"
-	"github.com/pkg/errors"
 )
 
 // WALGenerateNBlocks generates a consensus WAL. It does this by spinning up a
@@ -44,7 +43,7 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	privKeyType := config.PrivValidatorKeyType()
 	privValidator, err := privval.LoadOrGenFilePV(privValidatorKeyFile, privValidatorStateFile, privKeyType)
 	if err != nil {
-		return errors.Wrap(err, "failed to create a private key")
+		return fmt.Errorf("failed to load FilePV: %w", err)
 	}
 	genDoc, err := types.GenesisDocFromFile(config.GenesisFile())
 	if err != nil {
@@ -57,6 +56,7 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to make genesis state: %w", err)
 	}
+	state.ConsensusParams.Version.AppVersion = kvstore.ProtocolVersion
 	state.Version.Consensus.App = kvstore.ProtocolVersion
 	if err = stateStore.Save(state); err != nil {
 		t.Error(err)

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -210,7 +210,7 @@ func TestEvidencePoolUpdate(t *testing.T) {
 	ev := types.NewMockDuplicateVoteEvidenceWithValidator(height, defaultEvidenceTime.Add(21*time.Minute),
 		val, evidenceChainID)
 	lastCommit := makeCommit(height, val.PrivKey.PubKey().Address())
-	block := types.MakeBlock(height+1, []types.Tx{}, lastCommit, []types.Evidence{ev})
+	block := types.MakeBlock(height+1, []types.Tx{}, lastCommit, []types.Evidence{ev}, sm.InitStateVersion.Consensus)
 	// update state (partially)
 	state.LastBlockHeight = height + 1
 	state.LastBlockTime = defaultEvidenceTime.Add(22 * time.Minute)

--- a/evidence/pool_test.go
+++ b/evidence/pool_test.go
@@ -6,17 +6,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/line/ostracon/crypto"
-	"github.com/line/ostracon/crypto/bls"
-	"github.com/line/ostracon/crypto/composite"
-	"github.com/line/ostracon/crypto/ed25519"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	dbm "github.com/tendermint/tm-db"
 
+	"github.com/line/ostracon/crypto"
+	"github.com/line/ostracon/crypto/bls"
+	"github.com/line/ostracon/crypto/composite"
+	"github.com/line/ostracon/crypto/ed25519"
 	"github.com/line/ostracon/evidence"
 	"github.com/line/ostracon/evidence/mocks"
 	"github.com/line/ostracon/libs/log"
@@ -436,7 +435,7 @@ func initializeBlockStore(db dbm.DB, state sm.State, valPrivkey crypto.PrivKey) 
 		block, _ := state.MakeBlock(i, []types.Tx{}, lastCommit, nil,
 			state.Validators.SelectProposer(proof, i, round).Address, round, proof)
 		block.Header.Time = defaultEvidenceTime.Add(time.Duration(i) * time.Minute)
-		block.Header.Version = tmversion.Consensus{Block: version.BlockProtocol, App: 1}
+		block.Header.Version = tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol}
 		const parts = 1
 		partSet := block.MakePartSet(parts)
 

--- a/evidence/verify_test.go
+++ b/evidence/verify_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/line/ostracon/light"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -19,6 +17,7 @@ import (
 	"github.com/line/ostracon/evidence"
 	"github.com/line/ostracon/evidence/mocks"
 	"github.com/line/ostracon/libs/log"
+	"github.com/line/ostracon/light"
 	tmproto "github.com/line/ostracon/proto/ostracon/types"
 	tmversion "github.com/line/ostracon/proto/ostracon/version"
 	sm "github.com/line/ostracon/state"
@@ -725,7 +724,7 @@ func makeVote(
 
 func makeHeaderRandom(height int64) *types.Header {
 	return &types.Header{
-		Version:            tmversion.Consensus{Block: version.BlockProtocol, App: 1},
+		Version:            tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol},
 		ChainID:            evidenceChainID,
 		Height:             height,
 		Time:               defaultEvidenceTime,

--- a/light/helpers_test.go
+++ b/light/helpers_test.go
@@ -176,7 +176,7 @@ func genHeader(chainID string, height int64, bTime time.Time, txs types.Txs,
 	proof tmbytes.HexBytes) *types.Header {
 
 	return &types.Header{
-		Version: tmversion.Consensus{Block: version.BlockProtocol, App: 0},
+		Version: tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol},
 		ChainID: chainID,
 		Height:  height,
 		Time:    bTime,

--- a/light/store/db/db_test.go
+++ b/light/store/db/db_test.go
@@ -175,7 +175,7 @@ func randLightBlock(height int64) *types.LightBlock {
 	return &types.LightBlock{
 		SignedHeader: &types.SignedHeader{
 			Header: &types.Header{
-				Version:            tmversion.Consensus{Block: version.BlockProtocol, App: 0},
+				Version:            tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol},
 				ChainID:            tmrand.Str(12),
 				Height:             height,
 				Time:               time.Now(),

--- a/mempool/clist_mempool_system_test.go
+++ b/mempool/clist_mempool_system_test.go
@@ -18,8 +18,10 @@ import (
 	abci "github.com/line/ostracon/abci/types"
 	"github.com/line/ostracon/config"
 	"github.com/line/ostracon/libs/log"
+	tmversion "github.com/line/ostracon/proto/ostracon/version"
 	"github.com/line/ostracon/proxy"
 	"github.com/line/ostracon/types"
+	"github.com/line/ostracon/version"
 	"github.com/stretchr/testify/require"
 )
 
@@ -93,7 +95,10 @@ func createProposalBlockAndDeliverTxs(
 	mem *CListMempool, height int64) (*types.Block, []*abci.ResponseDeliverTx) {
 	// mempool.lock/unlock in ReapMaxBytesMaxGasMaxTxs
 	txs := mem.ReapMaxBytesMaxGasMaxTxs(mem.config.MaxTxsBytes, 0, int64(mem.config.Size))
-	block := types.MakeBlock(height, txs, nil, nil)
+	block := types.MakeBlock(height, txs, nil, nil, tmversion.Consensus{
+		Block: version.BlockProtocol,
+		App:   version.AppProtocol,
+	})
 	deliverTxResponses := make([]*abci.ResponseDeliverTx, len(block.Txs))
 	for i, tx := range block.Txs {
 		deliverTxResponses[i] = &abci.ResponseDeliverTx{

--- a/node/node.go
+++ b/node/node.go
@@ -360,7 +360,9 @@ func logNodeStartupInfo(state sm.State, pubKey crypto.PubKey, logger, consensusL
 	// Log the version info.
 	logger.Info("Version info",
 		"software", version.OCCoreSemVer,
-		"block", version.BlockProtocol,
+		"abci", version.ABCIVersion,
+		"app", state.Version.Consensus.App,
+		"block", state.Version.Consensus.Block,
 		"p2p", version.P2PProtocol,
 	)
 

--- a/p2p/node_info.go
+++ b/p2p/node_info.go
@@ -59,7 +59,7 @@ type ProtocolVersion struct {
 var defaultProtocolVersion = NewProtocolVersion(
 	version.P2PProtocol,
 	version.BlockProtocol,
-	0,
+	version.AppProtocol,
 )
 
 // NewProtocolVersion returns a fully populated ProtocolVersion.

--- a/state/execution_test.go
+++ b/state/execution_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/line/ostracon/libs/bytes"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -16,6 +14,7 @@ import (
 	"github.com/line/ostracon/crypto/ed25519"
 	cryptoenc "github.com/line/ostracon/crypto/encoding"
 	"github.com/line/ostracon/crypto/tmhash"
+	"github.com/line/ostracon/libs/bytes"
 	"github.com/line/ostracon/libs/log"
 	mmock "github.com/line/ostracon/mempool/mock"
 	tmproto "github.com/line/ostracon/proto/ostracon/types"
@@ -56,7 +55,7 @@ func TestApplyBlock(t *testing.T) {
 	assert.EqualValues(t, retainHeight, 1)
 
 	// TODO check state and mempool
-	assert.EqualValues(t, 1, state.Version.Consensus.App, "App version wasn't updated")
+	assert.EqualValues(t, TestAppVersion, state.Version.Consensus.App, "App version wasn't updated")
 }
 
 // TestBeginBlockValidators ensures we send absent validators list.
@@ -143,7 +142,7 @@ func TestBeginBlockByzantineValidators(t *testing.T) {
 	privVal := privVals[state.Validators.Validators[0].Address.String()]
 	blockID := makeBlockID([]byte("headerhash"), 1000, []byte("partshash"))
 	header := &types.Header{
-		Version:            tmversion.Consensus{Block: version.BlockProtocol, App: 1},
+		Version:            tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol},
 		ChainID:            state.ChainID,
 		Height:             10,
 		Time:               defaultEvidenceTime,

--- a/state/helpers_test.go
+++ b/state/helpers_test.go
@@ -257,6 +257,7 @@ type testApp struct {
 }
 
 var _ abci.Application = (*testApp)(nil)
+var TestAppVersion uint64 = 66
 
 func (app *testApp) Info(req abci.RequestInfo) (resInfo abci.ResponseInfo) {
 	return abci.ResponseInfo{}
@@ -273,7 +274,7 @@ func (app *testApp) EndBlock(req abci.RequestEndBlock) abci.ResponseEndBlock {
 		ValidatorUpdates: app.ValidatorUpdates,
 		ConsensusParamUpdates: &abci.ConsensusParams{
 			Version: &tmproto.VersionParams{
-				AppVersion: 1}}}
+				AppVersion: TestAppVersion}}}
 }
 
 func (app *testApp) DeliverTx(req abci.RequestDeliverTx) abci.ResponseDeliverTx {

--- a/state/rollback_test.go
+++ b/state/rollback_test.go
@@ -18,9 +18,8 @@ import (
 )
 
 var (
-	appVersion  uint64 = 10
-	proofHash          = []byte{0}
-	voterParams        = types.DefaultVoterParams()
+	proofHash   = []byte{0}
+	voterParams = types.DefaultVoterParams()
 )
 
 func TestRollback(t *testing.T) {
@@ -139,13 +138,13 @@ func setupStateStore(t *testing.T, height int64) state.Store {
 	nextValSet := initialValSet.CopyIncrementProposerPriority(1)
 
 	params := types.DefaultConsensusParams()
-	params.Version.AppVersion = appVersion
+	params.Version.AppVersion = 10
 
 	initialState := state.State{
 		Version: tmstate.Version{
 			Consensus: tmversion.Consensus{
 				Block: version.BlockProtocol,
-				App:   appVersion,
+				App:   10,
 			},
 			Software: version.OCCoreSemVer,
 		},

--- a/state/state.go
+++ b/state/state.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/line/ostracon/crypto"
-
 	tmstate "github.com/line/ostracon/proto/ostracon/state"
 	tmproto "github.com/line/ostracon/proto/ostracon/types"
 	tmversion "github.com/line/ostracon/proto/ostracon/version"
@@ -31,7 +30,7 @@ var (
 var InitStateVersion = tmstate.Version{
 	Consensus: tmversion.Consensus{
 		Block: version.BlockProtocol,
-		App:   0,
+		App:   version.AppProtocol,
 	},
 	Software: version.OCCoreSemVer,
 }

--- a/state/state.go
+++ b/state/state.go
@@ -275,7 +275,7 @@ func (state State) MakeBlock(
 ) (*types.Block, *types.PartSet) {
 
 	// Build base block with block data.
-	block := types.MakeBlock(height, txs, commit, evidence)
+	block := types.MakeBlock(height, txs, commit, evidence, state.Version.Consensus)
 
 	// Set time.
 	var timestamp time.Time

--- a/statesync/reactor_test.go
+++ b/statesync/reactor_test.go
@@ -242,7 +242,7 @@ func makeMockAppConnSnapshot(appHash string, snapshot *snapshot, chunks []*chunk
 func makeMockAppConnQuery(appHash string, height int64) *proxymocks.AppConnQuery {
 	connQuery := &proxymocks.AppConnQuery{}
 	connQuery.On("InfoSync", proxy.RequestInfo).Return(&abci.ResponseInfo{
-		AppVersion:       9,
+		AppVersion:       testAppVersion,
 		LastBlockHeight:  height,
 		LastBlockAppHash: []byte(appHash),
 	}, nil)
@@ -257,7 +257,7 @@ func makeTestStateAndCommit(appHash string, height int64) (sm.State, *types.Comm
 		Version: tmstate.Version{
 			Consensus: tmversion.Consensus{
 				Block: version.BlockProtocol,
-				App:   9,
+				App:   testAppVersion,
 			},
 
 			Software: version.OCCoreSemVer,
@@ -278,6 +278,7 @@ func makeTestStateAndCommit(appHash string, height int64) (sm.State, *types.Comm
 		ConsensusParams:                  *types.DefaultConsensusParams(),
 		LastHeightConsensusParamsChanged: 1,
 	}
+	state.ConsensusParams.Version.AppVersion = testAppVersion
 
 	commit := &types.Commit{BlockID: types.BlockID{Hash: []byte(blockHash)}}
 

--- a/statesync/stateprovider.go
+++ b/statesync/stateprovider.go
@@ -222,6 +222,7 @@ func (s *lightClientStateProvider) State(ctx context.Context, height uint64) (sm
 			nextLightBlock.Height, err)
 	}
 	state.ConsensusParams = result.ConsensusParams
+	state.Version.Consensus.App = state.ConsensusParams.Version.AppVersion
 	state.LastHeightConsensusParamsChanged = currentLightBlock.Height
 
 	// VoterParams

--- a/statesync/syncer.go
+++ b/statesync/syncer.go
@@ -489,6 +489,8 @@ func (s *syncer) requestChunk(snapshot *snapshot, chunk uint32) {
 
 // verifyApp verifies the sync, checking the app hash, last block height and app version
 func (s *syncer) verifyApp(snapshot *snapshot, appVersion uint64) error {
+	// XXX Is it okay to check with "ABCI.Info" only
+	// since AppVersion will be updated by "ABCI.InitChain" and "ABCI.EndBlock"?
 	resp, err := s.connQuery.InfoSync(proxy.RequestInfo)
 	if err != nil {
 		return fmt.Errorf("failed to query ABCI app for appHash: %w", err)
@@ -497,7 +499,7 @@ func (s *syncer) verifyApp(snapshot *snapshot, appVersion uint64) error {
 	// sanity check that the app version in the block matches the application's own record
 	// of its version
 	if resp.AppVersion != appVersion {
-		// An error here most likely means that the app hasn't inplemented state sync
+		// An error here most likely means that the app hasn't implemented state sync
 		// or the Info call correctly
 		return fmt.Errorf("app version mismatch. Expected: %d, got: %d",
 			appVersion, resp.AppVersion)

--- a/statesync/syncer_test.go
+++ b/statesync/syncer_test.go
@@ -2,6 +2,7 @@ package statesync
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -621,7 +622,8 @@ func TestSyncer_applyChunks_RejectSenders(t *testing.T) {
 func TestSyncer_verifyApp(t *testing.T) {
 	boom := errors.New("boom")
 	const appVersion = 9
-	appVersionMismatchErr := errors.New("app version mismatch. Expected: 9, got: 2")
+	const invalidAppVersion = appVersion + 1
+	appVersionMismatchErr := fmt.Errorf("app version mismatch. Expected: %d, got: %d", appVersion, invalidAppVersion)
 	s := &snapshot{Height: 3, Format: 1, Chunks: 5, Hash: []byte{1, 2, 3}, trustedAppHash: []byte("app_hash")}
 
 	testcases := map[string]struct {
@@ -637,7 +639,7 @@ func TestSyncer_verifyApp(t *testing.T) {
 		"invalid app version": {&abci.ResponseInfo{
 			LastBlockHeight:  3,
 			LastBlockAppHash: []byte("app_hash"),
-			AppVersion:       2,
+			AppVersion:       invalidAppVersion,
 		}, nil, appVersionMismatchErr},
 		"invalid height": {&abci.ResponseInfo{
 			LastBlockHeight:  5,

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -533,8 +533,10 @@ func TestLoadBlockMeta(t *testing.T) {
 
 	// 3. A good blockMeta serialized and saved to the DB should be retrievable
 	meta := &types.BlockMeta{Header: types.Header{
-		Version: tmversion.Consensus{
-			Block: version.BlockProtocol, App: 0}, Height: 1, ProposerAddress: tmrand.Bytes(crypto.AddressSize)}}
+		Version:         tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol},
+		Height:          1,
+		ProposerAddress: tmrand.Bytes(crypto.AddressSize)},
+	}
 	pbm := meta.ToProto()
 	err = db.Set(calcBlockMetaKey(height), mustEncode(pbm))
 	require.NoError(t, err)

--- a/test/e2e/app/app.go
+++ b/test/e2e/app/app.go
@@ -18,7 +18,7 @@ import (
 	"github.com/line/ostracon/version"
 )
 
-const appVersion = 1
+const E2EAppVersion = 999
 
 // Application is an ABCI application for use by end-to-end tests. It is a
 // simple key/value store for strings, storing data in memory and persisting
@@ -105,7 +105,7 @@ func NewApplication(cfg *Config) (*Application, error) {
 func (app *Application) Info(req abci.RequestInfo) abci.ResponseInfo {
 	return abci.ResponseInfo{
 		Version:          version.ABCIVersion,
-		AppVersion:       appVersion,
+		AppVersion:       E2EAppVersion,
 		LastBlockHeight:  int64(app.state.Height),
 		LastBlockAppHash: app.state.Hash,
 	}

--- a/test/e2e/runner/setup.go
+++ b/test/e2e/runner/setup.go
@@ -203,8 +203,6 @@ func MakeGenesis(testnet *e2e.Testnet) (types.GenesisDoc, error) {
 		ConsensusParams: types.DefaultConsensusParams(),
 		InitialHeight:   testnet.InitialHeight,
 	}
-	// set the app version to 1
-	genesis.ConsensusParams.Version.AppVersion = 1
 	for validator, power := range testnet.Validators {
 		genesis.Validators = append(genesis.Validators, types.GenesisValidator{
 			Name:    validator.Name,

--- a/test/fuzz/p2p/pex/reactor_receive.go
+++ b/test/fuzz/p2p/pex/reactor_receive.go
@@ -61,7 +61,7 @@ var defaultNodeInfo = p2p.DefaultNodeInfo{
 	ProtocolVersion: p2p.NewProtocolVersion(
 		version.P2PProtocol,
 		version.BlockProtocol,
-		0,
+		version.AppProtocol,
 	),
 	DefaultNodeID: nodeID,
 	ListenAddr:    "0.0.0.0:98992",

--- a/test/maverick/consensus/replay.go
+++ b/test/maverick/consensus/replay.go
@@ -262,6 +262,7 @@ func (h *Handshaker) Handshake(proxyApp proxy.AppConns) error {
 
 	// Only set the version if there is no existing state.
 	if h.initialState.LastBlockHeight == 0 {
+		h.initialState.ConsensusParams.Version.AppVersion = res.AppVersion
 		h.initialState.Version.Consensus.App = res.AppVersion
 	}
 
@@ -488,6 +489,7 @@ func (h *Handshaker) replayBlocks(
 
 	if mutateState {
 		// sync the final block
+		h.logger.Info("Replaying final block using real app", "height", storeBlockHeight)
 		state, err = h.replayBlock(state, storeBlockHeight, proxyApp.Consensus())
 		if err != nil {
 			return nil, err
@@ -503,13 +505,19 @@ func (h *Handshaker) replayBlocks(
 func (h *Handshaker) replayBlock(state sm.State, height int64, proxyApp proxy.AppConnConsensus) (sm.State, error) {
 	block := h.store.LoadBlock(height)
 	meta := h.store.LoadBlockMeta(height)
+	var err error
+	consensusParams, err := h.stateStore.LoadConsensusParams(height)
+	if err != nil {
+		return sm.State{}, err
+	}
+	state.ConsensusParams = consensusParams
+	state.Version.Consensus.App = consensusParams.Version.AppVersion
 
 	// Use stubs for both mempool and evidence pool since no transactions nor
 	// evidence are needed here - block already exists.
 	blockExec := sm.NewBlockExecutor(h.stateStore, h.logger, proxyApp, emptyMempool{}, sm.EmptyEvidencePool{})
 	blockExec.SetEventBus(h.eventBus)
 
-	var err error
 	state, _, err = blockExec.ApplyBlock(state, meta.BlockID, block, nil)
 	if err != nil {
 		return sm.State{}, err

--- a/test/maverick/consensus/wal_generator.go
+++ b/test/maverick/consensus/wal_generator.go
@@ -42,7 +42,8 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	// NOTE: we don't do handshake so need to set state.Version.Consensus.App directly.
 	privValidatorKeyFile := config.PrivValidatorKeyFile()
 	privValidatorStateFile := config.PrivValidatorStateFile()
-	privValidator, err := privval.LoadOrGenFilePV(privValidatorKeyFile, privValidatorStateFile, privval.PrivKeyTypeEd25519)
+	privKeyType := config.PrivValidatorKeyType()
+	privValidator, err := privval.LoadOrGenFilePV(privValidatorKeyFile, privValidatorStateFile, privKeyType)
 	if err != nil {
 		return fmt.Errorf("failed to load FilePV: %w", err)
 	}
@@ -57,6 +58,7 @@ func WALGenerateNBlocks(t *testing.T, wr io.Writer, numBlocks int) (err error) {
 	if err != nil {
 		return fmt.Errorf("failed to make genesis state: %w", err)
 	}
+	state.ConsensusParams.Version.AppVersion = kvstore.ProtocolVersion
 	state.Version.Consensus.App = kvstore.ProtocolVersion
 	if err = stateStore.Save(state); err != nil {
 		t.Error(err)

--- a/test/maverick/node/node.go
+++ b/test/maverick/node/node.go
@@ -356,6 +356,8 @@ func logNodeStartupInfo(state sm.State, pubKey crypto.PubKey, logger, consensusL
 	// Log the version info.
 	logger.Info("Version info",
 		"software", version.OCCoreSemVer,
+		"abci", version.ABCIVersion,
+		"app", version.AppProtocol,
 		"block", version.BlockProtocol,
 		"p2p", version.P2PProtocol,
 	)

--- a/types/block.go
+++ b/types/block.go
@@ -62,10 +62,10 @@ type Block struct {
 // MakeBlock returns a new block with an empty header, except what can be
 // computed from itself.
 // It populates the same set of fields validated by ValidateBasic.
-func MakeBlock(height int64, txs []Tx, lastCommit *Commit, evidence []Evidence) *Block {
+func MakeBlock(height int64, txs []Tx, lastCommit *Commit, evidence []Evidence, version tmversion.Consensus) *Block {
 	block := &Block{
 		Header: Header{
-			Version: tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol},
+			Version: version,
 			Height:  height,
 		},
 		Data: Data{

--- a/types/block.go
+++ b/types/block.go
@@ -65,7 +65,7 @@ type Block struct {
 func MakeBlock(height int64, txs []Tx, lastCommit *Commit, evidence []Evidence) *Block {
 	block := &Block{
 		Header: Header{
-			Version: tmversion.Consensus{Block: version.BlockProtocol, App: 0},
+			Version: tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol},
 			Height:  height,
 		},
 		Data: Data{

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -706,7 +706,7 @@ func TestHeaderValidateBasic(t *testing.T) {
 		i := i
 		t.Run(tc.testName, func(t *testing.T) {
 			header := &Header{
-				Version:            tmversion.Consensus{Block: version.BlockProtocol, App: 2},
+				Version:            tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol},
 				ChainID:            "chainId",
 				Height:             3,
 				Time:               time.Date(2019, 10, 13, 16, 14, 44, 0, time.UTC),
@@ -1339,7 +1339,7 @@ func makeRandHeader() Header {
 	randAddress := tmrand.Bytes(crypto.AddressSize)
 	randProof := tmrand.Bytes(vrf.ProofSize)
 	h := Header{
-		Version:            tmversion.Consensus{Block: version.BlockProtocol, App: 1},
+		Version:            tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol},
 		ChainID:            chainID,
 		Height:             height,
 		Time:               t,

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -34,6 +34,11 @@ import (
 	"github.com/line/ostracon/version"
 )
 
+var TestConsensusVersion = tmversion.Consensus{
+	Block: version.BlockProtocol,
+	App:   version.AppProtocol,
+}
+
 func TestMain(m *testing.M) {
 	code := m.Run()
 	os.Exit(code)
@@ -51,7 +56,7 @@ func TestBlockAddEvidence(t *testing.T) {
 	ev := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
 	evList := []Evidence{ev}
 
-	block := MakeBlock(h, txs, commit, evList)
+	block := MakeBlock(h, txs, commit, evList, TestConsensusVersion)
 	require.NotNil(t, block)
 	require.Equal(t, 1, len(block.Evidence.Evidence))
 	require.NotNil(t, block.EvidenceHash)
@@ -132,7 +137,7 @@ func TestBlockValidateBasic(t *testing.T) {
 		tc := tc
 		i := i
 		t.Run(tc.testName, func(t *testing.T) {
-			block := MakeBlock(h, txs, commit, evList)
+			block := MakeBlock(h, txs, commit, evList, TestConsensusVersion)
 			block.ProposerAddress = valSet.SelectProposer([]byte{}, block.Height, 0).Address
 			tc.malleateBlock(block)
 			err = block.ValidateBasic()
@@ -143,13 +148,13 @@ func TestBlockValidateBasic(t *testing.T) {
 
 func TestBlockHash(t *testing.T) {
 	assert.Nil(t, (*Block)(nil).Hash())
-	assert.Nil(t, MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil).Hash())
+	assert.Nil(t, MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil, TestConsensusVersion).Hash())
 }
 
 func TestBlockMakePartSet(t *testing.T) {
 	assert.Nil(t, (*Block)(nil).MakePartSet(2))
 
-	partSet := MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil).MakePartSet(1024)
+	partSet := MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil, TestConsensusVersion).MakePartSet(1024)
 	assert.NotNil(t, partSet)
 	assert.EqualValues(t, 1, partSet.Total())
 }
@@ -167,7 +172,7 @@ func TestBlockMakePartSetWithEvidence(t *testing.T) {
 	ev := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
 	evList := []Evidence{ev}
 
-	block := MakeBlock(h, []Tx{Tx("Hello World")}, commit, evList)
+	block := MakeBlock(h, []Tx{Tx("Hello World")}, commit, evList, TestConsensusVersion)
 	blockProto, err := block.ToProto()
 	assert.NoError(t, err)
 	bz, err := blockProto.Marshal()
@@ -190,7 +195,7 @@ func TestBlockHashesTo(t *testing.T) {
 	ev := NewMockDuplicateVoteEvidenceWithValidator(h, time.Now(), vals[0], "block-test-chain")
 	evList := []Evidence{ev}
 
-	block := MakeBlock(h, []Tx{Tx("Hello World")}, commit, evList)
+	block := MakeBlock(h, []Tx{Tx("Hello World")}, commit, evList, TestConsensusVersion)
 	block.ValidatorsHash = valSet.Hash()
 	block.VotersHash = voterSet.Hash()
 	assert.False(t, block.HashesTo([]byte{}))
@@ -199,7 +204,7 @@ func TestBlockHashesTo(t *testing.T) {
 }
 
 func TestBlockSize(t *testing.T) {
-	size := MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil).Size()
+	size := MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil, TestConsensusVersion).Size()
 	if size <= 0 {
 		t.Fatal("Size of the block is zero or negative")
 	}
@@ -210,7 +215,7 @@ func TestBlockString(t *testing.T) {
 	assert.Equal(t, "nil-Block", (*Block)(nil).StringIndented(""))
 	assert.Equal(t, "nil-Block", (*Block)(nil).StringShort())
 
-	block := MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil)
+	block := MakeBlock(int64(3), []Tx{Tx("Hello World")}, nil, nil, TestConsensusVersion)
 	assert.NotEqual(t, "nil-Block", block.String())
 	assert.NotEqual(t, "nil-Block", block.StringIndented(""))
 	assert.NotEqual(t, "nil-Block", block.StringShort())
@@ -1228,17 +1233,17 @@ func TestBlockIDValidateBasic(t *testing.T) {
 func TestBlockProtoBuf(t *testing.T) {
 	h := tmrand.Int63()
 	c1 := randCommit(time.Now())
-	b1 := MakeBlock(h, []Tx{Tx([]byte{1})}, &Commit{Signatures: []CommitSig{}}, []Evidence{})
+	b1 := MakeBlock(h, []Tx{Tx([]byte{1})}, &Commit{Signatures: []CommitSig{}}, []Evidence{}, TestConsensusVersion)
 	b1.ProposerAddress = tmrand.Bytes(crypto.AddressSize)
 
-	b2 := MakeBlock(h, []Tx{Tx([]byte{1})}, c1, []Evidence{})
+	b2 := MakeBlock(h, []Tx{Tx([]byte{1})}, c1, []Evidence{}, TestConsensusVersion)
 	b2.ProposerAddress = tmrand.Bytes(crypto.AddressSize)
 	evidenceTime := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
 	evi := NewMockDuplicateVoteEvidence(h, evidenceTime, "block-test-chain")
 	b2.Evidence = EvidenceData{Evidence: EvidenceList{evi}}
 	b2.EvidenceHash = b2.Evidence.Hash()
 
-	b3 := MakeBlock(h, []Tx{}, c1, []Evidence{})
+	b3 := MakeBlock(h, []Tx{}, c1, []Evidence{}, TestConsensusVersion)
 	b3.ProposerAddress = tmrand.Bytes(crypto.AddressSize)
 	testCases := []struct {
 		msg      string

--- a/types/event_bus_test.go
+++ b/types/event_bus_test.go
@@ -75,7 +75,7 @@ func TestEventBusPublishEventNewBlock(t *testing.T) {
 		}
 	})
 
-	block := MakeBlock(0, []Tx{}, nil, []Evidence{})
+	block := MakeBlock(0, []Tx{}, nil, []Evidence{}, TestConsensusVersion)
 	resultBeginBlock := abci.ResponseBeginBlock{
 		Events: []abci.Event{
 			{Type: "testType", Attributes: []abci.EventAttribute{{Key: []byte("baz"), Value: []byte("1")}}},
@@ -234,7 +234,7 @@ func TestEventBusPublishEventNewBlockHeader(t *testing.T) {
 		}
 	})
 
-	block := MakeBlock(0, []Tx{}, nil, []Evidence{})
+	block := MakeBlock(0, []Tx{}, nil, []Evidence{}, TestConsensusVersion)
 	resultBeginBlock := abci.ResponseBeginBlock{
 		Events: []abci.Event{
 			{Type: "testType", Attributes: []abci.EventAttribute{{Key: []byte("baz"), Value: []byte("1")}}},

--- a/types/evidence_test.go
+++ b/types/evidence_test.go
@@ -299,7 +299,7 @@ func makeVote(
 
 func makeHeaderRandom() *Header {
 	return &Header{
-		Version:            tmversion.Consensus{Block: version.BlockProtocol, App: 1},
+		Version:            tmversion.Consensus{Block: version.BlockProtocol, App: version.AppProtocol},
 		ChainID:            tmrand.Str(12),
 		Height:             int64(tmrand.Uint16()) + 1,
 		Time:               time.Now(),

--- a/types/params.go
+++ b/types/params.go
@@ -8,6 +8,7 @@ import (
 	abci "github.com/line/ostracon/abci/types"
 	"github.com/line/ostracon/crypto/tmhash"
 	tmproto "github.com/line/ostracon/proto/ostracon/types"
+	"github.com/line/ostracon/version"
 )
 
 const (
@@ -69,7 +70,7 @@ func DefaultValidatorParams() tmproto.ValidatorParams {
 
 func DefaultVersionParams() tmproto.VersionParams {
 	return tmproto.VersionParams{
-		AppVersion: 0,
+		AppVersion: version.AppProtocol,
 	}
 }
 

--- a/types/params_test.go
+++ b/types/params_test.go
@@ -145,9 +145,9 @@ func TestConsensusParamsUpdate_AppVersion(t *testing.T) {
 	assert.EqualValues(t, 0, params.Version.AppVersion)
 
 	updated := UpdateConsensusParams(params,
-		&abci.ConsensusParams{Version: &tmproto.VersionParams{AppVersion: 1}})
+		&abci.ConsensusParams{Version: &tmproto.VersionParams{AppVersion: 77}})
 
-	assert.EqualValues(t, 1, updated.Version.AppVersion)
+	assert.EqualValues(t, 77, updated.Version.AppVersion)
 }
 
 func TestVoterParamsValidate(t *testing.T) {

--- a/version/version.go
+++ b/version/version.go
@@ -21,4 +21,7 @@ var (
 	// BlockProtocol versions all block data structures and processing.
 	// This includes validity of blocks and state updates.
 	BlockProtocol uint64 = 11
+
+	// AppProtocol versions ABCI application.
+	AppProtocol uint64 = 0
 )


### PR DESCRIPTION
## Description

Cannot run a node after Rollback since there is a mismatch between "State.Version.Consensus.App" and "State.ConsensusParams.Version.AppVersion". While starting a node, Handshake is running. Until replaying the last Block do "ExecCommitBlock", but replaying the last Block is the same process as "ApplyBlock". It needs the correct "State" for the last Block.
And it also needs to fix the mismatch between "State.Version.Consensus" and "Block.Header.Consensus".
