### PR TITLE
Fix the order of paremeters in require.Equalf()

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -39,7 +39,7 @@ import (
 func TestNewOstraconNode(t *testing.T) {
 	config := cfg.ResetTestRootWithChainID("TestNewOstraconNode", "new_ostracon_node")
 	defer os.RemoveAll(config.RootDir)
-	require.Equal(t, config.PrivValidatorListenAddr, "")
+	require.Equal(t, "", config.PrivValidatorListenAddr)
 	node, err := NewOstraconNode(config, log.TestingLogger())
 	require.NoError(t, err)
 	pubKey, err := node.PrivValidator().GetPubKey()

--- a/rpc/jsonrpc/server/http_json_handler_test.go
+++ b/rpc/jsonrpc/server/http_json_handler_test.go
@@ -147,7 +147,7 @@ func TestRPCNotification(t *testing.T) {
 	blob, err := ioutil.ReadAll(res.Body)
 	res.Body.Close()
 	require.Nil(t, err, "reading from the body should not give back an error")
-	require.Equal(t, len(blob), 0, "a notification SHOULD NOT be responded to by the server")
+	require.Equal(t, 0, len(blob), "a notification SHOULD NOT be responded to by the server")
 }
 
 func TestRPCNotificationInBatch(t *testing.T) {

--- a/test/kms/bench_test.go
+++ b/test/kms/bench_test.go
@@ -85,8 +85,8 @@ func benchmarkGetPubKey(b *testing.B, pv types.PrivValidator) crypto.PubKey {
 
 	// evaluate execution results
 	require.NoError(b, err)
-	require.Equalf(b, len(pubKey.Bytes()), ed25519.PubKeySize, "PubKey: public key size = %d != %d",
-		len(pubKey.Bytes()), ed25519.PubKeySize)
+	require.Equalf(b, ed25519.PubKeySize, len(pubKey.Bytes()), "PubKey: public key size = %d != %d",
+		ed25519.PubKeySize, len(pubKey.Bytes()))
 	return pubKey
 }
 
@@ -120,8 +120,8 @@ func benchmarkSignVote(b *testing.B, pv types.PrivValidator, pubKey crypto.PubKe
 
 	// evaluate execution results
 	require.NoError(b, err)
-	require.Equalf(b, len(pb.Signature), ed25519.SignatureSize, "SignVote: signature size = %d != %d",
-		len(pb.Signature), ed25519.SignatureSize)
+	require.Equalf(b, ed25519.SignatureSize, len(pb.Signature), "SignVote: signature size = %d != %d",
+		ed25519.SignatureSize, len(pb.Signature))
 	bytes := types.VoteSignBytes(chainID, pb)
 	require.Truef(b, pubKey.VerifySignature(bytes, pb.Signature), "SignVote: signature verification")
 }
@@ -155,8 +155,8 @@ func benchmarkSignProposal(b *testing.B, pv types.PrivValidator, pubKey crypto.P
 
 	// evaluate execution results
 	require.NoError(b, err)
-	require.Equalf(b, len(pb.Signature), ed25519.SignatureSize, "SignProposal: signature size = %d != %d",
-		len(pb.Signature), ed25519.SignatureSize)
+	require.Equalf(b, ed25519.SignatureSize, len(pb.Signature), "SignProposal: signature size = %d != %d",
+		ed25519.SignatureSize, len(pb.Signature))
 	bytes := types.ProposalSignBytes(chainID, pb)
 	require.Truef(b, pubKey.VerifySignature(bytes, pb.Signature), "SignProposal: signature verification")
 }


### PR DESCRIPTION
## Description

In a few code the parameters passed to `require.Equalf()` and `require.Equal()` are `actual`, `expected` in that order, but they should be `expected`, `actual`.

Closes: #XXX

