### PR TITLE
Add entropy correctness test

### DIFF
--- a/types/block_test.go
+++ b/types/block_test.go
@@ -1183,7 +1183,7 @@ func TestEntropyProto(t *testing.T) {
 	}
 }
 
-func TestEntropyUniqueness(t *testing.T) {
+func TestEntropyCorrectness(t *testing.T) {
 	chainID := "test"
 	height := int64(1)
 	tx := []Tx{}
@@ -1216,10 +1216,10 @@ func TestEntropyUniqueness(t *testing.T) {
 	entropyDiffBlockId := BlockID{Hash: entropyDiffBlock.Hash(), PartSetHeader: entropyDiffBlock.MakePartSet(1024).Header()}
 
 	t.Run("test block id equality with different entropy", func(t *testing.T) {
-		assert.True(t, testBlockId.Equals(sameBlockId))
-		assert.False(t, testBlockId.Equals(roundDiffBlockId))
-		assert.False(t, testBlockId.Equals(proofDiffBlockId))
-		assert.False(t, testBlockId.Equals(entropyDiffBlockId))
+		assert.Equal(t, testBlockId, sameBlockId)
+		assert.NotEqual(t, testBlockId, roundDiffBlockId)
+		assert.NotEqual(t, testBlockId, proofDiffBlockId)
+		assert.NotEqual(t, testBlockId, entropyDiffBlockId)
 	})
 
 	t.Run("test vote signature verification with different entropy", func(t *testing.T) {

--- a/types/block_test.go
+++ b/types/block_test.go
@@ -1182,3 +1182,87 @@ func TestEntropyProto(t *testing.T) {
 		})
 	}
 }
+
+func TestEntropyUniqueness(t *testing.T) {
+	chainID := "test"
+	height := int64(1)
+	tx := []Tx{}
+	evList := []Evidence{}
+	commit := &Commit{}
+
+	round := int32(0)
+	proof := []byte("proof")
+	differentRound := round + 1
+	differentProof := []byte("different proof")
+
+	testBlock := MakeBlock(height, tx, commit, evList, TestConsensusVersion)
+	testBlock.Entropy.Populate(round, proof)
+	testBlockId := BlockID{Hash: testBlock.Hash(), PartSetHeader: testBlock.MakePartSet(1024).Header()}
+
+	sameBlock := MakeBlock(height, tx, commit, evList, TestConsensusVersion)
+	sameBlock.Entropy.Populate(round, proof)
+	sameBlockId := BlockID{Hash: sameBlock.Hash(), PartSetHeader: sameBlock.MakePartSet(1024).Header()}
+
+	roundDiffBlock := MakeBlock(height, tx, commit, evList, TestConsensusVersion)
+	roundDiffBlock.Entropy.Populate(differentRound, proof)
+	roundDiffBlockId := BlockID{Hash: roundDiffBlock.Hash(), PartSetHeader: roundDiffBlock.MakePartSet(1024).Header()}
+
+	proofDiffBlock := MakeBlock(height, tx, commit, evList, TestConsensusVersion)
+	proofDiffBlock.Entropy.Populate(round, differentProof)
+	proofDiffBlockId := BlockID{Hash: proofDiffBlock.Hash(), PartSetHeader: proofDiffBlock.MakePartSet(1024).Header()}
+
+	entropyDiffBlock := MakeBlock(height, tx, commit, evList, TestConsensusVersion)
+	entropyDiffBlock.Entropy.Populate(differentRound, differentProof)
+	entropyDiffBlockId := BlockID{Hash: entropyDiffBlock.Hash(), PartSetHeader: entropyDiffBlock.MakePartSet(1024).Header()}
+
+	t.Run("test block id equality with different entropy", func(t *testing.T) {
+		assert.True(t, testBlockId.Equals(sameBlockId))
+		assert.False(t, testBlockId.Equals(roundDiffBlockId))
+		assert.False(t, testBlockId.Equals(proofDiffBlockId))
+		assert.False(t, testBlockId.Equals(entropyDiffBlockId))
+	})
+
+	t.Run("test vote signature verification with different entropy", func(t *testing.T) {
+		_, privVals := RandValidatorSet(1, 1)
+		privVal := privVals[0]
+		pubKey, err := privVal.GetPubKey()
+		assert.NoError(t, err)
+
+		testVote := &Vote{
+			ValidatorAddress: pubKey.Address(),
+			ValidatorIndex:   0,
+			Height:           height,
+			Round:            0,
+			Timestamp:        tmtime.Now(),
+			Type:             tmproto.PrecommitType,
+			BlockID:          testBlockId,
+		}
+		tv := testVote.ToProto()
+		err = privVal.SignVote(chainID, tv)
+		assert.NoError(t, err)
+		testVote.Signature = tv.Signature
+
+		sameVote := testVote.Copy()
+		sameVote.BlockID = sameBlockId
+
+		roundDiffVote := testVote.Copy()
+		roundDiffVote.BlockID = roundDiffBlockId
+
+		proofDiffVote := testVote.Copy()
+		proofDiffVote.BlockID = proofDiffBlockId
+
+		entropyDiffVote := testVote.Copy()
+		entropyDiffVote.BlockID = entropyDiffBlockId
+
+		err = testVote.Verify(chainID, pubKey)
+		assert.NoError(t, err)
+		err = sameVote.Verify(chainID, pubKey)
+		assert.NoError(t, err)
+		err = roundDiffVote.Verify(chainID, pubKey)
+		assert.Error(t, err)
+		err = proofDiffVote.Verify(chainID, pubKey)
+		assert.Error(t, err)
+		err = entropyDiffVote.Verify(chainID, pubKey)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Description

PR #559 adds Entropy to Block and says that Entropy is single at every height. But that was not tested. So this PR adds a test that checks Entropy is single in every height. The following items need to be confirmed:

- BlockID has Markle roots of a block.
  - BlockID has PartSetHeader that has Markle roots of a block. Please see the following implementations.
  - https://github.com/line/ostracon/blob/7ca9a208a1729226638c503e019513ae3c8b76dd/types/part_set.go#L209-L217
  https://github.com/line/ostracon/blob/7ca9a208a1729226638c503e019513ae3c8b76dd/types/block.go#L171-L190
  https://github.com/line/ostracon/blob/7ca9a208a1729226638c503e019513ae3c8b76dd/types/part_set.go#L167-L195
- A block with different Entropy has a different BlockID.
  - This was not tested. So this PR adds this test.
- Signature of Vote with wrong PartSetHeader is invalid.
  - This was not tested. So this PR adds this test.
- All validators agree on the same Block.PartSetHeader as well as BlockID.Hash. 
  - Since [Commit](https://github.com/line/ostracon/blob/7ca9a208a1729226638c503e019513ae3c8b76dd/third_party/proto/tendermint/types/types.proto#L111) has only one BlockID, all validators agree on the same Block.PartSetHeader.

Closes: #XXX

