### PR TITLE
feat: big genesis file

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -1438,9 +1438,6 @@ func loadGenesisDoc(db dbm.DB) (*types.GenesisDoc, error) {
 	if err = iter.Close(); err != nil {
 		return nil, err
 	}
-	if err = iter.Error(); err != nil {
-		return nil, err
-	}
 
 	if len(b) == 0 {
 		return nil, errors.New("genesis doc not found")

--- a/node/node.go
+++ b/node/node.go
@@ -1463,10 +1463,6 @@ func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) error {
 
 	blockSize := 0x40000000 // 1gb
 	blocks := make([][]byte, 0)
-	lastBlockSize := len(b) % blockSize
-	if lastBlockSize == 0 {
-		lastBlockSize = blockSize
-	}
 	for i := 0; i < len(b); i += blockSize {
 		end := i + blockSize
 		if end > len(b) {
@@ -1478,7 +1474,10 @@ func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) error {
 	batch := db.NewBatch()
 	for i, block := range blocks {
 		k := append(genesisDocKey, byte(i))
-		batch.Set(k, block)
+		err = batch.Set(k, block)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err = batch.WriteSync(); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -1461,7 +1461,7 @@ func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) error {
 		return fmt.Errorf("failed to save genesis doc due to marshaling error: %w", err)
 	}
 
-	blockSize := 0x40000000 // 1gb
+	blockSize := 0x8000000 // 100mb
 	blocks := make([][]byte, 0)
 	for i := 0; i < len(b); i += blockSize {
 		end := i + blockSize

--- a/node/node.go
+++ b/node/node.go
@@ -1430,9 +1430,6 @@ func loadGenesisDoc(db dbm.DB) (*types.GenesisDoc, error) {
 	}
 
 	for ; iter.Valid(); iter.Next() {
-		if err != nil {
-			return nil, err
-		}
 		b = append(b, iter.Value()...)
 	}
 	if err = iter.Close(); err != nil {

--- a/node/node.go
+++ b/node/node.go
@@ -168,12 +168,12 @@ type fastSyncReactor interface {
 // WARNING: using any name from the below list of the existing reactors will
 // result in replacing it with the custom one.
 //
-//  - MEMPOOL
-//  - BLOCKCHAIN
-//  - CONSENSUS
-//  - EVIDENCE
-//  - PEX
-//  - STATESYNC
+//   - MEMPOOL
+//   - BLOCKCHAIN
+//   - CONSENSUS
+//   - EVIDENCE
+//   - PEX
+//   - STATESYNC
 func CustomReactors(reactors map[string]p2p.Reactor) Option {
 	return func(n *Node) {
 		for name, reactor := range reactors {
@@ -1461,7 +1461,7 @@ func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) error {
 		return fmt.Errorf("failed to save genesis doc due to marshaling error: %w", err)
 	}
 
-	blockSize := 0x40000000 // 1gb
+	blockSize := 100000000 // 100mb
 	blocks := make([][]byte, 0)
 	for i := 0; i < len(b); i += blockSize {
 		end := i + blockSize

--- a/node/node.go
+++ b/node/node.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	// "strconv"
 	"strings"
 	"time"
 
@@ -169,12 +168,12 @@ type fastSyncReactor interface {
 // WARNING: using any name from the below list of the existing reactors will
 // result in replacing it with the custom one.
 //
-//   - MEMPOOL
-//   - BLOCKCHAIN
-//   - CONSENSUS
-//   - EVIDENCE
-//   - PEX
-//   - STATESYNC
+//  - MEMPOOL
+//  - BLOCKCHAIN
+//  - CONSENSUS
+//  - EVIDENCE
+//  - PEX
+//  - STATESYNC
 func CustomReactors(reactors map[string]p2p.Reactor) Option {
 	return func(n *Node) {
 		for name, reactor := range reactors {

--- a/node/node.go
+++ b/node/node.go
@@ -168,12 +168,12 @@ type fastSyncReactor interface {
 // WARNING: using any name from the below list of the existing reactors will
 // result in replacing it with the custom one.
 //
-//   - MEMPOOL
-//   - BLOCKCHAIN
-//   - CONSENSUS
-//   - EVIDENCE
-//   - PEX
-//   - STATESYNC
+//  - MEMPOOL
+//  - BLOCKCHAIN
+//  - CONSENSUS
+//  - EVIDENCE
+//  - PEX
+//  - STATESYNC
 func CustomReactors(reactors map[string]p2p.Reactor) Option {
 	return func(n *Node) {
 		for name, reactor := range reactors {
@@ -1423,13 +1423,29 @@ func LoadStateFromDBOrGenesisDocProvider(
 
 // panics if failed to unmarshal bytes
 func loadGenesisDoc(db dbm.DB) (*types.GenesisDoc, error) {
-	b, err := db.Get(genesisDocKey)
+	var b []byte
+	iter, err := db.Iterator(append(genesisDocKey, byte(0)), append(genesisDocKey, byte(255)))
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
+
+	for ; iter.Valid(); iter.Next() {
+		if err != nil {
+			return nil, err
+		}
+		b = append(b, iter.Value()...)
+	}
+	if err = iter.Close(); err != nil {
+		return nil, err
+	}
+	if err = iter.Error(); err != nil {
+		return nil, err
+	}
+
 	if len(b) == 0 {
 		return nil, errors.New("genesis doc not found")
 	}
+
 	var genDoc *types.GenesisDoc
 	err = tmjson.Unmarshal(b, &genDoc)
 	if err != nil {
@@ -1444,7 +1460,27 @@ func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) error {
 	if err != nil {
 		return fmt.Errorf("failed to save genesis doc due to marshaling error: %w", err)
 	}
-	if err := db.SetSync(genesisDocKey, b); err != nil {
+
+	blockSize := 0x8000000 // 100mb
+	blocks := make([][]byte, 0)
+	for i := 0; i < len(b); i += blockSize {
+		end := i + blockSize
+		if end > len(b) {
+			end = len(b)
+		}
+		blocks = append(blocks, b[i:end])
+	}
+
+	batch := db.NewBatch()
+	for i, block := range blocks {
+		k := append(genesisDocKey, byte(i))
+		err = batch.Set(k, block)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err = batch.WriteSync(); err != nil {
 		return err
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -1461,7 +1461,7 @@ func saveGenesisDoc(db dbm.DB, genDoc *types.GenesisDoc) error {
 		return fmt.Errorf("failed to save genesis doc due to marshaling error: %w", err)
 	}
 
-	blockSize := 0x8000000 // 100mb
+	blockSize := 0x40000000 // 1gb
 	blocks := make([][]byte, 0)
 	for i := 0; i < len(b); i += blockSize {
 		end := i + blockSize

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -607,6 +608,21 @@ func TestNodeInvalidNodeInfoCustomReactors(t *testing.T) {
 		CustomReactors(map[string]p2p.Reactor{"FOO": cr, "BLOCKCHAIN": customBlockchainReactor}),
 	)
 	require.NoError(t, err)
+}
+
+func TestSaveAndLoadBigGensisFile(t *testing.T) {
+	stateDB := dbm.NewMemDB()
+	config := cfg.ResetTestRoot("node_big_genesis_test")
+	defer os.RemoveAll(config.RootDir)
+	n, err := DefaultNewNode(config, log.TestingLogger())
+	require.NoError(t, err)
+	newChainID := strings.Repeat("a", 2000000000) // about 2GB
+	n.genesisDoc.ChainID = newChainID
+	err = saveGenesisDoc(stateDB, n.genesisDoc)
+	require.NoError(t, err)
+	g, err := loadGenesisDoc(stateDB)
+	require.NoError(t, err)
+	require.Equal(t, newChainID, g.ChainID)
 }
 
 func NewInvalidNode(config *cfg.Config,

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -611,7 +611,7 @@ func TestNodeInvalidNodeInfoCustomReactors(t *testing.T) {
 }
 
 func TestSaveAndLoadBigGensisFile(t *testing.T) {
-	stateDB, err := dbm.NewDB("state", "goleveldb", os.TempDir())
+	stateDB, err := dbm.NewGoLevelDB("state", os.TempDir())
 	require.NoError(t, err)
 	config := cfg.ResetTestRoot("node_big_genesis_test")
 	defer os.RemoveAll(config.RootDir)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	// "strings"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -610,21 +610,21 @@ func TestNodeInvalidNodeInfoCustomReactors(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// func TestSaveAndLoadBigGensisFile(t *testing.T) {
-// 	stateDB := dbm.NewMemDB()
-// 	config := cfg.ResetTestRoot("node_big_genesis_test")
-// 	defer os.RemoveAll(config.RootDir)
-// 	n, err := DefaultNewNode(config, log.TestingLogger())
-// 	require.NoError(t, err)
-// 	newChainID := strings.Repeat("a", 300000000) // about 300MB
-// 	n.genesisDoc.ChainID = newChainID
-// 	err = saveGenesisDoc(stateDB, n.genesisDoc)
-// 	require.NoError(t, err)
-// 	g, err := loadGenesisDoc(stateDB)
-// 	require.NoError(t, err)
-// 	require.Equal(t, newChainID, g.ChainID)
-// 	stateDB.Close()
-// }
+func TestSaveAndLoadBigGensisFile(t *testing.T) {
+	stateDB := dbm.NewMemDB()
+	config := cfg.ResetTestRoot("node_big_genesis_test")
+	defer os.RemoveAll(config.RootDir)
+	n, err := DefaultNewNode(config, log.TestingLogger())
+	require.NoError(t, err)
+	newChainID := strings.Repeat("a", 300000000) // about 300MB
+	n.genesisDoc.ChainID = newChainID
+	err = saveGenesisDoc(stateDB, n.genesisDoc)
+	require.NoError(t, err)
+	g, err := loadGenesisDoc(stateDB)
+	require.NoError(t, err)
+	require.Equal(t, newChainID, g.ChainID)
+	stateDB.Close()
+}
 
 func NewInvalidNode(config *cfg.Config,
 	privValidator types.PrivValidator,

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -616,13 +616,14 @@ func TestSaveAndLoadBigGensisFile(t *testing.T) {
 	defer os.RemoveAll(config.RootDir)
 	n, err := DefaultNewNode(config, log.TestingLogger())
 	require.NoError(t, err)
-	newChainID := strings.Repeat("a", 2000000000) // about 2GB
+	newChainID := strings.Repeat("a", 300000000) // about 300MB
 	n.genesisDoc.ChainID = newChainID
 	err = saveGenesisDoc(stateDB, n.genesisDoc)
 	require.NoError(t, err)
 	g, err := loadGenesisDoc(stateDB)
 	require.NoError(t, err)
 	require.Equal(t, newChainID, g.ChainID)
+	stateDB.Close()
 }
 
 func NewInvalidNode(config *cfg.Config,

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -616,13 +616,14 @@ func TestSaveAndLoadBigGensisFile(t *testing.T) {
 	defer os.RemoveAll(config.RootDir)
 	n, err := DefaultNewNode(config, log.TestingLogger())
 	require.NoError(t, err)
-	newChainID := strings.Repeat("a", 2000000000) // about 2GB
+	newChainID := strings.Repeat("a", 200000000) // about 200MB
 	n.genesisDoc.ChainID = newChainID
 	err = saveGenesisDoc(stateDB, n.genesisDoc)
 	require.NoError(t, err)
 	g, err := loadGenesisDoc(stateDB)
 	require.NoError(t, err)
 	require.Equal(t, newChainID, g.ChainID)
+	stateDB.Close()
 }
 
 func NewInvalidNode(config *cfg.Config,

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
+	// "strings"
 	"syscall"
 	"testing"
 	"time"
@@ -610,21 +610,21 @@ func TestNodeInvalidNodeInfoCustomReactors(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestSaveAndLoadBigGensisFile(t *testing.T) {
-	stateDB := dbm.NewMemDB()
-	config := cfg.ResetTestRoot("node_big_genesis_test")
-	defer os.RemoveAll(config.RootDir)
-	n, err := DefaultNewNode(config, log.TestingLogger())
-	require.NoError(t, err)
-	newChainID := strings.Repeat("a", 300000000) // about 300MB
-	n.genesisDoc.ChainID = newChainID
-	err = saveGenesisDoc(stateDB, n.genesisDoc)
-	require.NoError(t, err)
-	g, err := loadGenesisDoc(stateDB)
-	require.NoError(t, err)
-	require.Equal(t, newChainID, g.ChainID)
-	stateDB.Close()
-}
+// func TestSaveAndLoadBigGensisFile(t *testing.T) {
+// 	stateDB := dbm.NewMemDB()
+// 	config := cfg.ResetTestRoot("node_big_genesis_test")
+// 	defer os.RemoveAll(config.RootDir)
+// 	n, err := DefaultNewNode(config, log.TestingLogger())
+// 	require.NoError(t, err)
+// 	newChainID := strings.Repeat("a", 300000000) // about 300MB
+// 	n.genesisDoc.ChainID = newChainID
+// 	err = saveGenesisDoc(stateDB, n.genesisDoc)
+// 	require.NoError(t, err)
+// 	g, err := loadGenesisDoc(stateDB)
+// 	require.NoError(t, err)
+// 	require.Equal(t, newChainID, g.ChainID)
+// 	stateDB.Close()
+// }
 
 func NewInvalidNode(config *cfg.Config,
 	privValidator types.PrivValidator,

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -611,7 +611,8 @@ func TestNodeInvalidNodeInfoCustomReactors(t *testing.T) {
 }
 
 func TestSaveAndLoadBigGensisFile(t *testing.T) {
-	stateDB := dbm.NewMemDB()
+	stateDB, err := dbm.NewDB("state", "goleveldb", os.TempDir())
+	require.NoError(t, err)
 	config := cfg.ResetTestRoot("node_big_genesis_test")
 	defer os.RemoveAll(config.RootDir)
 	n, err := DefaultNewNode(config, log.TestingLogger())

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -616,14 +616,13 @@ func TestSaveAndLoadBigGensisFile(t *testing.T) {
 	defer os.RemoveAll(config.RootDir)
 	n, err := DefaultNewNode(config, log.TestingLogger())
 	require.NoError(t, err)
-	newChainID := strings.Repeat("a", 300000000) // about 300MB
+	newChainID := strings.Repeat("a", 2000000000) // about 2GB
 	n.genesisDoc.ChainID = newChainID
 	err = saveGenesisDoc(stateDB, n.genesisDoc)
 	require.NoError(t, err)
 	g, err := loadGenesisDoc(stateDB)
 	require.NoError(t, err)
 	require.Equal(t, newChainID, g.ChainID)
-	stateDB.Close()
 }
 
 func NewInvalidNode(config *cfg.Config,


### PR DESCRIPTION
## Description

As the genesis.json file based migration progressed, the function to write and load large files to the db was required. The block size of leveldb is limited to 4gb. Therefore, if the genesis.json file exceeds 4gb, a way to divide and save it is needed.

- It divide the genesis data into `100MB` units and save them in the db as keys `genesisDoc0`, `genesisDoc1`, ... `genesisDoc255` (here int means byte). When divided into larger units (1GB, ...), the test could not be successed due to ci error, so the size was set at 100MB. Also, since `100MB * 255 = 25.5GB` in this case, I figured it would be fine in most cases.

Closes: #577 

